### PR TITLE
style: prefix all colors with `#` + use better `macos-icon-*` colors

### DIFF
--- a/templates/ghostty-base16.mustache
+++ b/templates/ghostty-base16.mustache
@@ -29,13 +29,15 @@ palette = 20=#{{ base04-hex }}
 palette = 21=#{{ base06-hex }}
 
 # Foreground & background colors
-background = {{ base00-hex }}
-foreground = {{ base05-hex }}
-cursor-color = {{ base05-hex }}
-selection-background = {{ base02-hex }}
-selection-foreground = {{ base05-hex }}
+background = #{{ base00-hex }}
+foreground = #{{ base05-hex }}
+cursor-color = #{{ base05-hex }}
+selection-background = #{{ base02-hex }}
+selection-foreground = #{{ base05-hex }}
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = {{ base05-hex }}
-macos-icon-screen-color = {{ base00-hex }}
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #{{ base07-hex }}
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #{{ base0D-hex }}

--- a/templates/ghostty-base24.mustache
+++ b/templates/ghostty-base24.mustache
@@ -29,13 +29,15 @@ palette = 20=#{{ base04-hex }}
 palette = 21=#{{ base06-hex }}
 
 # Foreground & background colors
-background = {{ base00-hex }}
-foreground = {{ base05-hex }}
-cursor-color = {{ base05-hex }}
-selection-background = {{ base02-hex }}
-selection-foreground = {{ base05-hex }}
+background = #{{ base00-hex }}
+foreground = #{{ base05-hex }}
+cursor-color = #{{ base05-hex }}
+selection-background = #{{ base02-hex }}
+selection-foreground = #{{ base05-hex }}
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = {{ base05-hex }}
-macos-icon-screen-color = {{ base00-hex }}
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #{{ base07-hex }}
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #{{ base16-hex }}

--- a/themes/ghostty/base16-3024
+++ b/themes/ghostty/base16-3024
@@ -29,13 +29,15 @@ palette = 20=#807d7c
 palette = 21=#d6d5d4
 
 # Foreground & background colors
-background = 090300
-foreground = a5a2a2
-cursor-color = a5a2a2
-selection-background = 4a4543
-selection-foreground = a5a2a2
+background = #090300
+foreground = #a5a2a2
+cursor-color = #a5a2a2
+selection-background = #4a4543
+selection-foreground = #a5a2a2
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = a5a2a2
-macos-icon-screen-color = 090300
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #f7f7f7
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #01a0e4

--- a/themes/ghostty/base16-apathy
+++ b/themes/ghostty/base16-apathy
@@ -29,13 +29,15 @@ palette = 20=#5f9c92
 palette = 21=#a7cec8
 
 # Foreground & background colors
-background = 031a16
-foreground = 81b5ac
-cursor-color = 81b5ac
-selection-background = 184e45
-selection-foreground = 81b5ac
+background = #031a16
+foreground = #81b5ac
+cursor-color = #81b5ac
+selection-background = #184e45
+selection-foreground = #81b5ac
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 81b5ac
-macos-icon-screen-color = 031a16
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #d2e7e4
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #96883e

--- a/themes/ghostty/base16-apprentice
+++ b/themes/ghostty/base16-apprentice
@@ -29,13 +29,15 @@ palette = 20=#5f87af
 palette = 21=#5f8787
 
 # Foreground & background colors
-background = 262626
-foreground = 5f5f87
-cursor-color = 5f5f87
-selection-background = 5f875f
-selection-foreground = 5f5f87
+background = #262626
+foreground = #5f5f87
+cursor-color = #5f5f87
+selection-background = #5f875f
+selection-foreground = #5f5f87
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 5f5f87
-macos-icon-screen-color = 262626
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #6c6c6c
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #8787af

--- a/themes/ghostty/base16-ashes
+++ b/themes/ghostty/base16-ashes
@@ -29,13 +29,15 @@ palette = 20=#adb3ba
 palette = 21=#dfe2e5
 
 # Foreground & background colors
-background = 1c2023
-foreground = c7ccd1
-cursor-color = c7ccd1
-selection-background = 565e65
-selection-foreground = c7ccd1
+background = #1c2023
+foreground = #c7ccd1
+cursor-color = #c7ccd1
+selection-background = #565e65
+selection-foreground = #c7ccd1
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = c7ccd1
-macos-icon-screen-color = 1c2023
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #f3f4f5
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #ae95c7

--- a/themes/ghostty/base16-atelier-cave
+++ b/themes/ghostty/base16-atelier-cave
@@ -29,13 +29,15 @@ palette = 20=#7e7887
 palette = 21=#e2dfe7
 
 # Foreground & background colors
-background = 19171c
-foreground = 8b8792
-cursor-color = 8b8792
-selection-background = 585260
-selection-foreground = 8b8792
+background = #19171c
+foreground = #8b8792
+cursor-color = #8b8792
+selection-background = #585260
+selection-foreground = #8b8792
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 8b8792
-macos-icon-screen-color = 19171c
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #efecf4
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #576ddb

--- a/themes/ghostty/base16-atelier-cave-light
+++ b/themes/ghostty/base16-atelier-cave-light
@@ -29,13 +29,15 @@ palette = 20=#655f6d
 palette = 21=#26232a
 
 # Foreground & background colors
-background = efecf4
-foreground = 585260
-cursor-color = 585260
-selection-background = 8b8792
-selection-foreground = 585260
+background = #efecf4
+foreground = #585260
+cursor-color = #585260
+selection-background = #8b8792
+selection-foreground = #585260
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 585260
-macos-icon-screen-color = efecf4
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #19171c
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #576ddb

--- a/themes/ghostty/base16-atelier-dune
+++ b/themes/ghostty/base16-atelier-dune
@@ -29,13 +29,15 @@ palette = 20=#999580
 palette = 21=#e8e4cf
 
 # Foreground & background colors
-background = 20201d
-foreground = a6a28c
-cursor-color = a6a28c
-selection-background = 6e6b5e
-selection-foreground = a6a28c
+background = #20201d
+foreground = #a6a28c
+cursor-color = #a6a28c
+selection-background = #6e6b5e
+selection-foreground = #a6a28c
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = a6a28c
-macos-icon-screen-color = 20201d
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #fefbec
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #6684e1

--- a/themes/ghostty/base16-atelier-dune-light
+++ b/themes/ghostty/base16-atelier-dune-light
@@ -29,13 +29,15 @@ palette = 20=#7d7a68
 palette = 21=#292824
 
 # Foreground & background colors
-background = fefbec
-foreground = 6e6b5e
-cursor-color = 6e6b5e
-selection-background = a6a28c
-selection-foreground = 6e6b5e
+background = #fefbec
+foreground = #6e6b5e
+cursor-color = #6e6b5e
+selection-background = #a6a28c
+selection-foreground = #6e6b5e
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 6e6b5e
-macos-icon-screen-color = fefbec
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #20201d
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #6684e1

--- a/themes/ghostty/base16-atelier-estuary
+++ b/themes/ghostty/base16-atelier-estuary
@@ -29,13 +29,15 @@ palette = 20=#878573
 palette = 21=#e7e6df
 
 # Foreground & background colors
-background = 22221b
-foreground = 929181
-cursor-color = 929181
-selection-background = 5f5e4e
-selection-foreground = 929181
+background = #22221b
+foreground = #929181
+cursor-color = #929181
+selection-background = #5f5e4e
+selection-foreground = #929181
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 929181
-macos-icon-screen-color = 22221b
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #f4f3ec
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #36a166

--- a/themes/ghostty/base16-atelier-estuary-light
+++ b/themes/ghostty/base16-atelier-estuary-light
@@ -29,13 +29,15 @@ palette = 20=#6c6b5a
 palette = 21=#302f27
 
 # Foreground & background colors
-background = f4f3ec
-foreground = 5f5e4e
-cursor-color = 5f5e4e
-selection-background = 929181
-selection-foreground = 5f5e4e
+background = #f4f3ec
+foreground = #5f5e4e
+cursor-color = #5f5e4e
+selection-background = #929181
+selection-foreground = #5f5e4e
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 5f5e4e
-macos-icon-screen-color = f4f3ec
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #22221b
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #36a166

--- a/themes/ghostty/base16-atelier-forest
+++ b/themes/ghostty/base16-atelier-forest
@@ -29,13 +29,15 @@ palette = 20=#9c9491
 palette = 21=#e6e2e0
 
 # Foreground & background colors
-background = 1b1918
-foreground = a8a19f
-cursor-color = a8a19f
-selection-background = 68615e
-selection-foreground = a8a19f
+background = #1b1918
+foreground = #a8a19f
+cursor-color = #a8a19f
+selection-background = #68615e
+selection-foreground = #a8a19f
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = a8a19f
-macos-icon-screen-color = 1b1918
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #f1efee
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #407ee7

--- a/themes/ghostty/base16-atelier-forest-light
+++ b/themes/ghostty/base16-atelier-forest-light
@@ -29,13 +29,15 @@ palette = 20=#766e6b
 palette = 21=#2c2421
 
 # Foreground & background colors
-background = f1efee
-foreground = 68615e
-cursor-color = 68615e
-selection-background = a8a19f
-selection-foreground = 68615e
+background = #f1efee
+foreground = #68615e
+cursor-color = #68615e
+selection-background = #a8a19f
+selection-foreground = #68615e
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 68615e
-macos-icon-screen-color = f1efee
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #1b1918
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #407ee7

--- a/themes/ghostty/base16-atelier-heath
+++ b/themes/ghostty/base16-atelier-heath
@@ -29,13 +29,15 @@ palette = 20=#9e8f9e
 palette = 21=#d8cad8
 
 # Foreground & background colors
-background = 1b181b
-foreground = ab9bab
-cursor-color = ab9bab
-selection-background = 695d69
-selection-foreground = ab9bab
+background = #1b181b
+foreground = #ab9bab
+cursor-color = #ab9bab
+selection-background = #695d69
+selection-foreground = #ab9bab
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = ab9bab
-macos-icon-screen-color = 1b181b
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #f7f3f7
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #516aec

--- a/themes/ghostty/base16-atelier-heath-light
+++ b/themes/ghostty/base16-atelier-heath-light
@@ -29,13 +29,15 @@ palette = 20=#776977
 palette = 21=#292329
 
 # Foreground & background colors
-background = f7f3f7
-foreground = 695d69
-cursor-color = 695d69
-selection-background = ab9bab
-selection-foreground = 695d69
+background = #f7f3f7
+foreground = #695d69
+cursor-color = #695d69
+selection-background = #ab9bab
+selection-foreground = #695d69
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 695d69
-macos-icon-screen-color = f7f3f7
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #1b181b
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #516aec

--- a/themes/ghostty/base16-atelier-lakeside
+++ b/themes/ghostty/base16-atelier-lakeside
@@ -29,13 +29,15 @@ palette = 20=#7195a8
 palette = 21=#c1e4f6
 
 # Foreground & background colors
-background = 161b1d
-foreground = 7ea2b4
-cursor-color = 7ea2b4
-selection-background = 516d7b
-selection-foreground = 7ea2b4
+background = #161b1d
+foreground = #7ea2b4
+cursor-color = #7ea2b4
+selection-background = #516d7b
+selection-foreground = #7ea2b4
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 7ea2b4
-macos-icon-screen-color = 161b1d
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ebf8ff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #257fad

--- a/themes/ghostty/base16-atelier-lakeside-light
+++ b/themes/ghostty/base16-atelier-lakeside-light
@@ -29,13 +29,15 @@ palette = 20=#5a7b8c
 palette = 21=#1f292e
 
 # Foreground & background colors
-background = ebf8ff
-foreground = 516d7b
-cursor-color = 516d7b
-selection-background = 7ea2b4
-selection-foreground = 516d7b
+background = #ebf8ff
+foreground = #516d7b
+cursor-color = #516d7b
+selection-background = #7ea2b4
+selection-foreground = #516d7b
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 516d7b
-macos-icon-screen-color = ebf8ff
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #161b1d
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #257fad

--- a/themes/ghostty/base16-atelier-plateau
+++ b/themes/ghostty/base16-atelier-plateau
@@ -29,13 +29,15 @@ palette = 20=#7e7777
 palette = 21=#e7dfdf
 
 # Foreground & background colors
-background = 1b1818
-foreground = 8a8585
-cursor-color = 8a8585
-selection-background = 585050
-selection-foreground = 8a8585
+background = #1b1818
+foreground = #8a8585
+cursor-color = #8a8585
+selection-background = #585050
+selection-foreground = #8a8585
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 8a8585
-macos-icon-screen-color = 1b1818
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #f4ecec
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #7272ca

--- a/themes/ghostty/base16-atelier-plateau-light
+++ b/themes/ghostty/base16-atelier-plateau-light
@@ -29,13 +29,15 @@ palette = 20=#655d5d
 palette = 21=#292424
 
 # Foreground & background colors
-background = f4ecec
-foreground = 585050
-cursor-color = 585050
-selection-background = 8a8585
-selection-foreground = 585050
+background = #f4ecec
+foreground = #585050
+cursor-color = #585050
+selection-background = #8a8585
+selection-foreground = #585050
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 585050
-macos-icon-screen-color = f4ecec
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #1b1818
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #7272ca

--- a/themes/ghostty/base16-atelier-savanna
+++ b/themes/ghostty/base16-atelier-savanna
@@ -29,13 +29,15 @@ palette = 20=#78877d
 palette = 21=#dfe7e2
 
 # Foreground & background colors
-background = 171c19
-foreground = 87928a
-cursor-color = 87928a
-selection-background = 526057
-selection-foreground = 87928a
+background = #171c19
+foreground = #87928a
+cursor-color = #87928a
+selection-background = #526057
+selection-foreground = #87928a
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 87928a
-macos-icon-screen-color = 171c19
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ecf4ee
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #478c90

--- a/themes/ghostty/base16-atelier-savanna-light
+++ b/themes/ghostty/base16-atelier-savanna-light
@@ -29,13 +29,15 @@ palette = 20=#5f6d64
 palette = 21=#232a25
 
 # Foreground & background colors
-background = ecf4ee
-foreground = 526057
-cursor-color = 526057
-selection-background = 87928a
-selection-foreground = 526057
+background = #ecf4ee
+foreground = #526057
+cursor-color = #526057
+selection-background = #87928a
+selection-foreground = #526057
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 526057
-macos-icon-screen-color = ecf4ee
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #171c19
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #478c90

--- a/themes/ghostty/base16-atelier-seaside
+++ b/themes/ghostty/base16-atelier-seaside
@@ -29,13 +29,15 @@ palette = 20=#809980
 palette = 21=#cfe8cf
 
 # Foreground & background colors
-background = 131513
-foreground = 8ca68c
-cursor-color = 8ca68c
-selection-background = 5e6e5e
-selection-foreground = 8ca68c
+background = #131513
+foreground = #8ca68c
+cursor-color = #8ca68c
+selection-background = #5e6e5e
+selection-foreground = #8ca68c
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 8ca68c
-macos-icon-screen-color = 131513
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #f4fbf4
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #3d62f5

--- a/themes/ghostty/base16-atelier-seaside-light
+++ b/themes/ghostty/base16-atelier-seaside-light
@@ -29,13 +29,15 @@ palette = 20=#687d68
 palette = 21=#242924
 
 # Foreground & background colors
-background = f4fbf4
-foreground = 5e6e5e
-cursor-color = 5e6e5e
-selection-background = 8ca68c
-selection-foreground = 5e6e5e
+background = #f4fbf4
+foreground = #5e6e5e
+cursor-color = #5e6e5e
+selection-background = #8ca68c
+selection-foreground = #5e6e5e
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 5e6e5e
-macos-icon-screen-color = f4fbf4
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #131513
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #3d62f5

--- a/themes/ghostty/base16-atelier-sulphurpool
+++ b/themes/ghostty/base16-atelier-sulphurpool
@@ -29,13 +29,15 @@ palette = 20=#898ea4
 palette = 21=#dfe2f1
 
 # Foreground & background colors
-background = 202746
-foreground = 979db4
-cursor-color = 979db4
-selection-background = 5e6687
-selection-foreground = 979db4
+background = #202746
+foreground = #979db4
+cursor-color = #979db4
+selection-background = #5e6687
+selection-foreground = #979db4
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 979db4
-macos-icon-screen-color = 202746
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #f5f7ff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #3d8fd1

--- a/themes/ghostty/base16-atelier-sulphurpool-light
+++ b/themes/ghostty/base16-atelier-sulphurpool-light
@@ -29,13 +29,15 @@ palette = 20=#6b7394
 palette = 21=#293256
 
 # Foreground & background colors
-background = f5f7ff
-foreground = 5e6687
-cursor-color = 5e6687
-selection-background = 979db4
-selection-foreground = 5e6687
+background = #f5f7ff
+foreground = #5e6687
+cursor-color = #5e6687
+selection-background = #979db4
+selection-foreground = #5e6687
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 5e6687
-macos-icon-screen-color = f5f7ff
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #202746
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #3d8fd1

--- a/themes/ghostty/base16-atlas
+++ b/themes/ghostty/base16-atlas
@@ -29,13 +29,15 @@ palette = 20=#869696
 palette = 21=#e6e6dc
 
 # Foreground & background colors
-background = 002635
-foreground = a1a19a
-cursor-color = a1a19a
-selection-background = 517f8d
-selection-foreground = a1a19a
+background = #002635
+foreground = #a1a19a
+cursor-color = #a1a19a
+selection-background = #517f8d
+selection-foreground = #a1a19a
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = a1a19a
-macos-icon-screen-color = 002635
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #fafaf8
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #14747e

--- a/themes/ghostty/base16-ayu-dark
+++ b/themes/ghostty/base16-ayu-dark
@@ -29,13 +29,15 @@ palette = 20=#bfbdb6
 palette = 21=#e6e1cf
 
 # Foreground & background colors
-background = 0f1419
-foreground = e6e1cf
-cursor-color = e6e1cf
-selection-background = 272d38
-selection-foreground = e6e1cf
+background = #0f1419
+foreground = #e6e1cf
+cursor-color = #e6e1cf
+selection-background = #272d38
+selection-foreground = #e6e1cf
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = e6e1cf
-macos-icon-screen-color = 0f1419
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #f3f4f5
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #59c2ff

--- a/themes/ghostty/base16-ayu-light
+++ b/themes/ghostty/base16-ayu-light
@@ -29,13 +29,15 @@ palette = 20=#828c99
 palette = 21=#242936
 
 # Foreground & background colors
-background = fafafa
-foreground = 5c6773
-cursor-color = 5c6773
-selection-background = f8f9fa
-selection-foreground = 5c6773
+background = #fafafa
+foreground = #5c6773
+cursor-color = #5c6773
+selection-background = #f8f9fa
+selection-foreground = #5c6773
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 5c6773
-macos-icon-screen-color = fafafa
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #1a1f29
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #36a3d9

--- a/themes/ghostty/base16-ayu-mirage
+++ b/themes/ghostty/base16-ayu-mirage
@@ -29,13 +29,15 @@ palette = 20=#8a9199
 palette = 21=#d9d7ce
 
 # Foreground & background colors
-background = 171b24
-foreground = cccac2
-cursor-color = cccac2
-selection-background = 242936
-selection-foreground = cccac2
+background = #171b24
+foreground = #cccac2
+cursor-color = #cccac2
+selection-background = #242936
+selection-foreground = #cccac2
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = cccac2
-macos-icon-screen-color = 171b24
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #f3f4f5
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #5ccfe6

--- a/themes/ghostty/base16-aztec
+++ b/themes/ghostty/base16-aztec
@@ -29,13 +29,15 @@ palette = 20=#ffd129
 palette = 21=#ffe178
 
 # Foreground & background colors
-background = 101600
-foreground = ffda51
-cursor-color = ffda51
-selection-background = 242604
-selection-foreground = ffda51
+background = #101600
+foreground = #ffda51
+cursor-color = #ffda51
+selection-background = #242604
+selection-foreground = #ffda51
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = ffda51
-macos-icon-screen-color = 101600
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffeba0
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #5b4a9f

--- a/themes/ghostty/base16-bespin
+++ b/themes/ghostty/base16-bespin
@@ -29,13 +29,15 @@ palette = 20=#797977
 palette = 21=#9d9b97
 
 # Foreground & background colors
-background = 28211c
-foreground = 8a8986
-cursor-color = 8a8986
-selection-background = 5e5d5c
-selection-foreground = 8a8986
+background = #28211c
+foreground = #8a8986
+cursor-color = #8a8986
+selection-background = #5e5d5c
+selection-foreground = #8a8986
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 8a8986
-macos-icon-screen-color = 28211c
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #baae9e
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #5ea6ea

--- a/themes/ghostty/base16-black-metal
+++ b/themes/ghostty/base16-black-metal
@@ -29,13 +29,15 @@ palette = 20=#999999
 palette = 21=#999999
 
 # Foreground & background colors
-background = 000000
-foreground = c1c1c1
-cursor-color = c1c1c1
-selection-background = 222222
-selection-foreground = c1c1c1
+background = #000000
+foreground = #c1c1c1
+cursor-color = #c1c1c1
+selection-background = #222222
+selection-foreground = #c1c1c1
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = c1c1c1
-macos-icon-screen-color = 000000
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #c1c1c1
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #888888

--- a/themes/ghostty/base16-black-metal-bathory
+++ b/themes/ghostty/base16-black-metal-bathory
@@ -29,13 +29,15 @@ palette = 20=#999999
 palette = 21=#999999
 
 # Foreground & background colors
-background = 000000
-foreground = c1c1c1
-cursor-color = c1c1c1
-selection-background = 222222
-selection-foreground = c1c1c1
+background = #000000
+foreground = #c1c1c1
+cursor-color = #c1c1c1
+selection-background = #222222
+selection-foreground = #c1c1c1
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = c1c1c1
-macos-icon-screen-color = 000000
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #c1c1c1
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #888888

--- a/themes/ghostty/base16-black-metal-burzum
+++ b/themes/ghostty/base16-black-metal-burzum
@@ -29,13 +29,15 @@ palette = 20=#999999
 palette = 21=#999999
 
 # Foreground & background colors
-background = 000000
-foreground = c1c1c1
-cursor-color = c1c1c1
-selection-background = 222222
-selection-foreground = c1c1c1
+background = #000000
+foreground = #c1c1c1
+cursor-color = #c1c1c1
+selection-background = #222222
+selection-foreground = #c1c1c1
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = c1c1c1
-macos-icon-screen-color = 000000
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #c1c1c1
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #888888

--- a/themes/ghostty/base16-black-metal-dark-funeral
+++ b/themes/ghostty/base16-black-metal-dark-funeral
@@ -29,13 +29,15 @@ palette = 20=#999999
 palette = 21=#999999
 
 # Foreground & background colors
-background = 000000
-foreground = c1c1c1
-cursor-color = c1c1c1
-selection-background = 222222
-selection-foreground = c1c1c1
+background = #000000
+foreground = #c1c1c1
+cursor-color = #c1c1c1
+selection-background = #222222
+selection-foreground = #c1c1c1
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = c1c1c1
-macos-icon-screen-color = 000000
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #c1c1c1
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #888888

--- a/themes/ghostty/base16-black-metal-gorgoroth
+++ b/themes/ghostty/base16-black-metal-gorgoroth
@@ -29,13 +29,15 @@ palette = 20=#999999
 palette = 21=#999999
 
 # Foreground & background colors
-background = 000000
-foreground = c1c1c1
-cursor-color = c1c1c1
-selection-background = 222222
-selection-foreground = c1c1c1
+background = #000000
+foreground = #c1c1c1
+cursor-color = #c1c1c1
+selection-background = #222222
+selection-foreground = #c1c1c1
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = c1c1c1
-macos-icon-screen-color = 000000
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #c1c1c1
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #888888

--- a/themes/ghostty/base16-black-metal-immortal
+++ b/themes/ghostty/base16-black-metal-immortal
@@ -29,13 +29,15 @@ palette = 20=#999999
 palette = 21=#999999
 
 # Foreground & background colors
-background = 000000
-foreground = c1c1c1
-cursor-color = c1c1c1
-selection-background = 222222
-selection-foreground = c1c1c1
+background = #000000
+foreground = #c1c1c1
+cursor-color = #c1c1c1
+selection-background = #222222
+selection-foreground = #c1c1c1
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = c1c1c1
-macos-icon-screen-color = 000000
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #c1c1c1
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #888888

--- a/themes/ghostty/base16-black-metal-khold
+++ b/themes/ghostty/base16-black-metal-khold
@@ -29,13 +29,15 @@ palette = 20=#999999
 palette = 21=#999999
 
 # Foreground & background colors
-background = 000000
-foreground = c1c1c1
-cursor-color = c1c1c1
-selection-background = 222222
-selection-foreground = c1c1c1
+background = #000000
+foreground = #c1c1c1
+cursor-color = #c1c1c1
+selection-background = #222222
+selection-foreground = #c1c1c1
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = c1c1c1
-macos-icon-screen-color = 000000
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #c1c1c1
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #888888

--- a/themes/ghostty/base16-black-metal-marduk
+++ b/themes/ghostty/base16-black-metal-marduk
@@ -29,13 +29,15 @@ palette = 20=#999999
 palette = 21=#999999
 
 # Foreground & background colors
-background = 000000
-foreground = c1c1c1
-cursor-color = c1c1c1
-selection-background = 222222
-selection-foreground = c1c1c1
+background = #000000
+foreground = #c1c1c1
+cursor-color = #c1c1c1
+selection-background = #222222
+selection-foreground = #c1c1c1
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = c1c1c1
-macos-icon-screen-color = 000000
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #c1c1c1
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #888888

--- a/themes/ghostty/base16-black-metal-mayhem
+++ b/themes/ghostty/base16-black-metal-mayhem
@@ -29,13 +29,15 @@ palette = 20=#999999
 palette = 21=#999999
 
 # Foreground & background colors
-background = 000000
-foreground = c1c1c1
-cursor-color = c1c1c1
-selection-background = 222222
-selection-foreground = c1c1c1
+background = #000000
+foreground = #c1c1c1
+cursor-color = #c1c1c1
+selection-background = #222222
+selection-foreground = #c1c1c1
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = c1c1c1
-macos-icon-screen-color = 000000
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #c1c1c1
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #888888

--- a/themes/ghostty/base16-black-metal-nile
+++ b/themes/ghostty/base16-black-metal-nile
@@ -29,13 +29,15 @@ palette = 20=#999999
 palette = 21=#999999
 
 # Foreground & background colors
-background = 000000
-foreground = c1c1c1
-cursor-color = c1c1c1
-selection-background = 222222
-selection-foreground = c1c1c1
+background = #000000
+foreground = #c1c1c1
+cursor-color = #c1c1c1
+selection-background = #222222
+selection-foreground = #c1c1c1
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = c1c1c1
-macos-icon-screen-color = 000000
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #c1c1c1
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #888888

--- a/themes/ghostty/base16-black-metal-venom
+++ b/themes/ghostty/base16-black-metal-venom
@@ -29,13 +29,15 @@ palette = 20=#999999
 palette = 21=#999999
 
 # Foreground & background colors
-background = 000000
-foreground = c1c1c1
-cursor-color = c1c1c1
-selection-background = 222222
-selection-foreground = c1c1c1
+background = #000000
+foreground = #c1c1c1
+cursor-color = #c1c1c1
+selection-background = #222222
+selection-foreground = #c1c1c1
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = c1c1c1
-macos-icon-screen-color = 000000
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #c1c1c1
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #888888

--- a/themes/ghostty/base16-blueforest
+++ b/themes/ghostty/base16-blueforest
@@ -29,13 +29,15 @@ palette = 20=#1e5c1e
 palette = 21=#91ccff
 
 # Foreground & background colors
-background = 141f2e
-foreground = ffcc33
-cursor-color = ffcc33
-selection-background = 273e5c
-selection-foreground = ffcc33
+background = #141f2e
+foreground = #ffcc33
+cursor-color = #ffcc33
+selection-background = #273e5c
+selection-foreground = #ffcc33
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = ffcc33
-macos-icon-screen-color = 141f2e
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #375780
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #a2cff5

--- a/themes/ghostty/base16-blueish
+++ b/themes/ghostty/base16-blueish
@@ -29,13 +29,15 @@ palette = 20=#74afe7
 palette = 21=#ddeaf6
 
 # Foreground & background colors
-background = 182430
-foreground = c8e1f8
-cursor-color = c8e1f8
-selection-background = 46290a
-selection-foreground = c8e1f8
+background = #182430
+foreground = #c8e1f8
+cursor-color = #c8e1f8
+selection-background = #46290a
+selection-foreground = #c8e1f8
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = c8e1f8
-macos-icon-screen-color = 182430
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #8f98a0
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #82aaff

--- a/themes/ghostty/base16-brewer
+++ b/themes/ghostty/base16-brewer
@@ -29,13 +29,15 @@ palette = 20=#959697
 palette = 21=#dadbdc
 
 # Foreground & background colors
-background = 0c0d0e
-foreground = b7b8b9
-cursor-color = b7b8b9
-selection-background = 515253
-selection-foreground = b7b8b9
+background = #0c0d0e
+foreground = #b7b8b9
+cursor-color = #b7b8b9
+selection-background = #515253
+selection-foreground = #b7b8b9
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = b7b8b9
-macos-icon-screen-color = 0c0d0e
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #fcfdfe
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #3182bd

--- a/themes/ghostty/base16-bright
+++ b/themes/ghostty/base16-bright
@@ -29,13 +29,15 @@ palette = 20=#d0d0d0
 palette = 21=#f5f5f5
 
 # Foreground & background colors
-background = 000000
-foreground = e0e0e0
-cursor-color = e0e0e0
-selection-background = 505050
-selection-foreground = e0e0e0
+background = #000000
+foreground = #e0e0e0
+cursor-color = #e0e0e0
+selection-background = #505050
+selection-foreground = #e0e0e0
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = e0e0e0
-macos-icon-screen-color = 000000
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #6fb3d2

--- a/themes/ghostty/base16-brogrammer
+++ b/themes/ghostty/base16-brogrammer
@@ -29,13 +29,15 @@ palette = 20=#2a84d2
 palette = 21=#1081d6
 
 # Foreground & background colors
-background = 1f1f1f
-foreground = 4e5ab7
-cursor-color = 4e5ab7
-selection-background = 2dc55e
-selection-foreground = 4e5ab7
+background = #1f1f1f
+foreground = #4e5ab7
+cursor-color = #4e5ab7
+selection-background = #2dc55e
+selection-foreground = #4e5ab7
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 4e5ab7
-macos-icon-screen-color = 1f1f1f
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #d6dbe5
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #5350b9

--- a/themes/ghostty/base16-brushtrees
+++ b/themes/ghostty/base16-brushtrees
@@ -29,13 +29,15 @@ palette = 20=#8299a1
 palette = 21=#5a6d7a
 
 # Foreground & background colors
-background = e3efef
-foreground = 6d828e
-cursor-color = 6d828e
-selection-background = b0c5c8
-selection-foreground = 6d828e
+background = #e3efef
+foreground = #6d828e
+cursor-color = #6d828e
+selection-background = #b0c5c8
+selection-foreground = #6d828e
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 6d828e
-macos-icon-screen-color = e3efef
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #485867
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #868cb3

--- a/themes/ghostty/base16-brushtrees-dark
+++ b/themes/ghostty/base16-brushtrees-dark
@@ -29,13 +29,15 @@ palette = 20=#98afb5
 palette = 21=#c9dbdc
 
 # Foreground & background colors
-background = 485867
-foreground = b0c5c8
-cursor-color = b0c5c8
-selection-background = 6d828e
-selection-foreground = b0c5c8
+background = #485867
+foreground = #b0c5c8
+cursor-color = #b0c5c8
+selection-background = #6d828e
+selection-foreground = #b0c5c8
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = b0c5c8
-macos-icon-screen-color = 485867
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #e3efef
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #868cb3

--- a/themes/ghostty/base16-caroline
+++ b/themes/ghostty/base16-caroline
@@ -29,13 +29,15 @@ palette = 20=#8b5d57
 palette = 21=#c58d7b
 
 # Foreground & background colors
-background = 1c1213
-foreground = a87569
-cursor-color = a87569
-selection-background = 563837
-selection-foreground = a87569
+background = #1c1213
+foreground = #a87569
+cursor-color = #a87569
+selection-background = #563837
+selection-foreground = #a87569
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = a87569
-macos-icon-screen-color = 1c1213
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #e3a68c
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #684c59

--- a/themes/ghostty/base16-catppuccin-frappe
+++ b/themes/ghostty/base16-catppuccin-frappe
@@ -29,13 +29,15 @@ palette = 20=#626880
 palette = 21=#f2d5cf
 
 # Foreground & background colors
-background = 303446
-foreground = c6d0f5
-cursor-color = c6d0f5
-selection-background = 414559
-selection-foreground = c6d0f5
+background = #303446
+foreground = #c6d0f5
+cursor-color = #c6d0f5
+selection-background = #414559
+selection-foreground = #c6d0f5
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = c6d0f5
-macos-icon-screen-color = 303446
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #babbf1
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #8caaee

--- a/themes/ghostty/base16-catppuccin-latte
+++ b/themes/ghostty/base16-catppuccin-latte
@@ -29,13 +29,15 @@ palette = 20=#acb0be
 palette = 21=#dc8a78
 
 # Foreground & background colors
-background = eff1f5
-foreground = 4c4f69
-cursor-color = 4c4f69
-selection-background = ccd0da
-selection-foreground = 4c4f69
+background = #eff1f5
+foreground = #4c4f69
+cursor-color = #4c4f69
+selection-background = #ccd0da
+selection-foreground = #4c4f69
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 4c4f69
-macos-icon-screen-color = eff1f5
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #7287fd
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #1e66f5

--- a/themes/ghostty/base16-catppuccin-macchiato
+++ b/themes/ghostty/base16-catppuccin-macchiato
@@ -29,13 +29,15 @@ palette = 20=#5b6078
 palette = 21=#f4dbd6
 
 # Foreground & background colors
-background = 24273a
-foreground = cad3f5
-cursor-color = cad3f5
-selection-background = 363a4f
-selection-foreground = cad3f5
+background = #24273a
+foreground = #cad3f5
+cursor-color = #cad3f5
+selection-background = #363a4f
+selection-foreground = #cad3f5
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = cad3f5
-macos-icon-screen-color = 24273a
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #b7bdf8
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #8aadf4

--- a/themes/ghostty/base16-catppuccin-mocha
+++ b/themes/ghostty/base16-catppuccin-mocha
@@ -29,13 +29,15 @@ palette = 20=#585b70
 palette = 21=#f5e0dc
 
 # Foreground & background colors
-background = 1e1e2e
-foreground = cdd6f4
-cursor-color = cdd6f4
-selection-background = 313244
-selection-foreground = cdd6f4
+background = #1e1e2e
+foreground = #cdd6f4
+cursor-color = #cdd6f4
+selection-background = #313244
+selection-foreground = #cdd6f4
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = cdd6f4
-macos-icon-screen-color = 1e1e2e
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #b4befe
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #89b4fa

--- a/themes/ghostty/base16-chalk
+++ b/themes/ghostty/base16-chalk
@@ -29,13 +29,15 @@ palette = 20=#b0b0b0
 palette = 21=#e0e0e0
 
 # Foreground & background colors
-background = 151515
-foreground = d0d0d0
-cursor-color = d0d0d0
-selection-background = 303030
-selection-foreground = d0d0d0
+background = #151515
+foreground = #d0d0d0
+cursor-color = #d0d0d0
+selection-background = #303030
+selection-foreground = #d0d0d0
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = d0d0d0
-macos-icon-screen-color = 151515
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #f5f5f5
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #6fc2ef

--- a/themes/ghostty/base16-circus
+++ b/themes/ghostty/base16-circus
@@ -29,13 +29,15 @@ palette = 20=#505050
 palette = 21=#808080
 
 # Foreground & background colors
-background = 191919
-foreground = a7a7a7
-cursor-color = a7a7a7
-selection-background = 303030
-selection-foreground = a7a7a7
+background = #191919
+foreground = #a7a7a7
+cursor-color = #a7a7a7
+selection-background = #303030
+selection-foreground = #a7a7a7
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = a7a7a7
-macos-icon-screen-color = 191919
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #639ee4

--- a/themes/ghostty/base16-classic-dark
+++ b/themes/ghostty/base16-classic-dark
@@ -29,13 +29,15 @@ palette = 20=#b0b0b0
 palette = 21=#e0e0e0
 
 # Foreground & background colors
-background = 151515
-foreground = d0d0d0
-cursor-color = d0d0d0
-selection-background = 303030
-selection-foreground = d0d0d0
+background = #151515
+foreground = #d0d0d0
+cursor-color = #d0d0d0
+selection-background = #303030
+selection-foreground = #d0d0d0
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = d0d0d0
-macos-icon-screen-color = 151515
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #f5f5f5
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #6a9fb5

--- a/themes/ghostty/base16-classic-light
+++ b/themes/ghostty/base16-classic-light
@@ -29,13 +29,15 @@ palette = 20=#505050
 palette = 21=#202020
 
 # Foreground & background colors
-background = f5f5f5
-foreground = 303030
-cursor-color = 303030
-selection-background = d0d0d0
-selection-foreground = 303030
+background = #f5f5f5
+foreground = #303030
+cursor-color = #303030
+selection-background = #d0d0d0
+selection-foreground = #303030
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 303030
-macos-icon-screen-color = f5f5f5
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #151515
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #6a9fb5

--- a/themes/ghostty/base16-codeschool
+++ b/themes/ghostty/base16-codeschool
@@ -29,13 +29,15 @@ palette = 20=#84898c
 palette = 21=#a7cfa3
 
 # Foreground & background colors
-background = 232c31
-foreground = 9ea7a6
-cursor-color = 9ea7a6
-selection-background = 2a343a
-selection-foreground = 9ea7a6
+background = #232c31
+foreground = #9ea7a6
+cursor-color = #9ea7a6
+selection-background = #2a343a
+selection-foreground = #9ea7a6
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 9ea7a6
-macos-icon-screen-color = 232c31
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #b5d8f6
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #484d79

--- a/themes/ghostty/base16-colors
+++ b/themes/ghostty/base16-colors
@@ -29,13 +29,15 @@ palette = 20=#999999
 palette = 21=#dddddd
 
 # Foreground & background colors
-background = 111111
-foreground = bbbbbb
-cursor-color = bbbbbb
-selection-background = 555555
-selection-foreground = bbbbbb
+background = #111111
+foreground = #bbbbbb
+cursor-color = #bbbbbb
+selection-background = #555555
+selection-foreground = #bbbbbb
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = bbbbbb
-macos-icon-screen-color = 111111
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #0074d9

--- a/themes/ghostty/base16-cupcake
+++ b/themes/ghostty/base16-cupcake
@@ -29,13 +29,15 @@ palette = 20=#a59daf
 palette = 21=#72677e
 
 # Foreground & background colors
-background = fbf1f2
-foreground = 8b8198
-cursor-color = 8b8198
-selection-background = d8d5dd
-selection-foreground = 8b8198
+background = #fbf1f2
+foreground = #8b8198
+cursor-color = #8b8198
+selection-background = #d8d5dd
+selection-foreground = #8b8198
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 8b8198
-macos-icon-screen-color = fbf1f2
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #585062
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #7297b9

--- a/themes/ghostty/base16-cupertino
+++ b/themes/ghostty/base16-cupertino
@@ -29,13 +29,15 @@ palette = 20=#808080
 palette = 21=#404040
 
 # Foreground & background colors
-background = ffffff
-foreground = 404040
-cursor-color = 404040
-selection-background = c0c0c0
-selection-foreground = 404040
+background = #ffffff
+foreground = #404040
+cursor-color = #404040
+selection-background = #c0c0c0
+selection-foreground = #404040
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 404040
-macos-icon-screen-color = ffffff
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #5e5e5e
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #0000ff

--- a/themes/ghostty/base16-da-one-black
+++ b/themes/ghostty/base16-da-one-black
@@ -29,13 +29,15 @@ palette = 20=#c8c8c8
 palette = 21=#ffffff
 
 # Foreground & background colors
-background = 000000
-foreground = ffffff
-cursor-color = ffffff
-selection-background = 585858
-selection-foreground = ffffff
+background = #000000
+foreground = #ffffff
+cursor-color = #ffffff
+selection-background = #585858
+selection-foreground = #ffffff
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = ffffff
-macos-icon-screen-color = 000000
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #6bb8ff

--- a/themes/ghostty/base16-da-one-gray
+++ b/themes/ghostty/base16-da-one-gray
@@ -29,13 +29,15 @@ palette = 20=#c8c8c8
 palette = 21=#ffffff
 
 # Foreground & background colors
-background = 181818
-foreground = ffffff
-cursor-color = ffffff
-selection-background = 585858
-selection-foreground = ffffff
+background = #181818
+foreground = #ffffff
+cursor-color = #ffffff
+selection-background = #585858
+selection-foreground = #ffffff
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = ffffff
-macos-icon-screen-color = 181818
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #6bb8ff

--- a/themes/ghostty/base16-da-one-ocean
+++ b/themes/ghostty/base16-da-one-ocean
@@ -29,13 +29,15 @@ palette = 20=#c8c8c8
 palette = 21=#ffffff
 
 # Foreground & background colors
-background = 171726
-foreground = ffffff
-cursor-color = ffffff
-selection-background = 525866
-selection-foreground = ffffff
+background = #171726
+foreground = #ffffff
+cursor-color = #ffffff
+selection-background = #525866
+selection-foreground = #ffffff
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = ffffff
-macos-icon-screen-color = 171726
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #6bb8ff

--- a/themes/ghostty/base16-da-one-paper
+++ b/themes/ghostty/base16-da-one-paper
@@ -29,13 +29,15 @@ palette = 20=#282828
 palette = 21=#000000
 
 # Foreground & background colors
-background = faf0dc
-foreground = 181818
-cursor-color = 181818
-selection-background = 888888
-selection-foreground = 181818
+background = #faf0dc
+foreground = #181818
+cursor-color = #181818
+selection-background = #888888
+selection-foreground = #181818
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 181818
-macos-icon-screen-color = faf0dc
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #000000
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #5890f8

--- a/themes/ghostty/base16-da-one-sea
+++ b/themes/ghostty/base16-da-one-sea
@@ -29,13 +29,15 @@ palette = 20=#c8c8c8
 palette = 21=#ffffff
 
 # Foreground & background colors
-background = 22273d
-foreground = ffffff
-cursor-color = ffffff
-selection-background = 525866
-selection-foreground = ffffff
+background = #22273d
+foreground = #ffffff
+cursor-color = #ffffff
+selection-background = #525866
+selection-foreground = #ffffff
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = ffffff
-macos-icon-screen-color = 22273d
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #6bb8ff

--- a/themes/ghostty/base16-da-one-white
+++ b/themes/ghostty/base16-da-one-white
@@ -29,13 +29,15 @@ palette = 20=#282828
 palette = 21=#000000
 
 # Foreground & background colors
-background = ffffff
-foreground = 181818
-cursor-color = 181818
-selection-background = 888888
-selection-foreground = 181818
+background = #ffffff
+foreground = #181818
+cursor-color = #181818
+selection-background = #888888
+selection-foreground = #181818
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 181818
-macos-icon-screen-color = ffffff
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #000000
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #5890f8

--- a/themes/ghostty/base16-danqing
+++ b/themes/ghostty/base16-danqing
@@ -29,13 +29,15 @@ palette = 20=#cad8d2
 palette = 21=#ecf6f2
 
 # Foreground & background colors
-background = 2d302f
-foreground = e0f0ef
-cursor-color = e0f0ef
-selection-background = 5a605d
-selection-foreground = e0f0ef
+background = #2d302f
+foreground = #e0f0ef
+cursor-color = #e0f0ef
+selection-background = #5a605d
+selection-foreground = #e0f0ef
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = e0f0ef
-macos-icon-screen-color = 2d302f
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #fcfefd
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #b0a4e3

--- a/themes/ghostty/base16-danqing-light
+++ b/themes/ghostty/base16-danqing-light
@@ -29,13 +29,15 @@ palette = 20=#9da8a3
 palette = 21=#434846
 
 # Foreground & background colors
-background = fcfefd
-foreground = 5a605d
-cursor-color = 5a605d
-selection-background = e0f0ef
-selection-foreground = 5a605d
+background = #fcfefd
+foreground = #5a605d
+cursor-color = #5a605d
+selection-background = #e0f0ef
+selection-foreground = #5a605d
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 5a605d
-macos-icon-screen-color = fcfefd
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #2d302f
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #b0a4e3

--- a/themes/ghostty/base16-darcula
+++ b/themes/ghostty/base16-darcula
@@ -29,13 +29,15 @@ palette = 20=#a4a3a3
 palette = 21=#ffc66d
 
 # Foreground & background colors
-background = 2b2b2b
-foreground = a9b7c6
-cursor-color = a9b7c6
-selection-background = 323232
-selection-foreground = a9b7c6
+background = #2b2b2b
+foreground = #a9b7c6
+cursor-color = #a9b7c6
+selection-background = #323232
+selection-foreground = #a9b7c6
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = a9b7c6
-macos-icon-screen-color = 2b2b2b
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #9876aa

--- a/themes/ghostty/base16-darkmoss
+++ b/themes/ghostty/base16-darkmoss
@@ -29,13 +29,15 @@ palette = 20=#818f80
 palette = 21=#e3e3c8
 
 # Foreground & background colors
-background = 171e1f
-foreground = c7c7a5
-cursor-color = c7c7a5
-selection-background = 373c3d
-selection-foreground = c7c7a5
+background = #171e1f
+foreground = #c7c7a5
+cursor-color = #c7c7a5
+selection-background = #373c3d
+selection-foreground = #c7c7a5
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = c7c7a5
-macos-icon-screen-color = 171e1f
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #e1eaef
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #498091

--- a/themes/ghostty/base16-darktooth
+++ b/themes/ghostty/base16-darktooth
@@ -29,13 +29,15 @@ palette = 20=#928374
 palette = 21=#d5c4a1
 
 # Foreground & background colors
-background = 1d2021
-foreground = a89984
-cursor-color = a89984
-selection-background = 504945
-selection-foreground = a89984
+background = #1d2021
+foreground = #a89984
+cursor-color = #a89984
+selection-background = #504945
+selection-foreground = #a89984
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = a89984
-macos-icon-screen-color = 1d2021
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #fdf4c1
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #0d6678

--- a/themes/ghostty/base16-darkviolet
+++ b/themes/ghostty/base16-darkviolet
@@ -29,13 +29,15 @@ palette = 20=#00ff00
 palette = 21=#9045e6
 
 # Foreground & background colors
-background = 000000
-foreground = b08ae6
-cursor-color = b08ae6
-selection-background = 432d59
-selection-foreground = b08ae6
+background = #000000
+foreground = #b08ae6
+cursor-color = #b08ae6
+selection-background = #432d59
+selection-foreground = #b08ae6
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = b08ae6
-macos-icon-screen-color = 000000
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #a366ff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #4136d9

--- a/themes/ghostty/base16-decaf
+++ b/themes/ghostty/base16-decaf
@@ -29,13 +29,15 @@ palette = 20=#b4b7b4
 palette = 21=#e0e0e0
 
 # Foreground & background colors
-background = 2d2d2d
-foreground = cccccc
-cursor-color = cccccc
-selection-background = 515151
-selection-foreground = cccccc
+background = #2d2d2d
+foreground = #cccccc
+cursor-color = #cccccc
+selection-background = #515151
+selection-foreground = #cccccc
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = cccccc
-macos-icon-screen-color = 2d2d2d
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #90bee1

--- a/themes/ghostty/base16-deep-oceanic-next
+++ b/themes/ghostty/base16-deep-oceanic-next
@@ -1,41 +1,43 @@
 # vim: ft=ghostty
 # Deep Oceanic Next theme for Ghostty
-# Scheme Author: spearkkk (https://github.com/spearkkk/deep-oceanic-next)
+# Scheme Author: spearkkk (https://github.com/spearkkk)
 # Scheme System: base16
 # Template Author: Tinted Terminal (https://github.com/tinted-theming/tinted-terminal)
 
 # Color palette
-palette = 0=#003b46
-palette = 1=#e6454b
-palette = 2=#85b57a
-palette = 3=#ffcc66
-palette = 4=#3a82e6
-palette = 5=#8c4de6
-palette = 6=#4da6a6
-palette = 7=#dce3e8
-palette = 8=#006374
-palette = 9=#e6454b
-palette = 10=#85b57a
-palette = 11=#ffcc66
-palette = 12=#3a82e6
-palette = 13=#8c4de6
-palette = 14=#4da6a6
-palette = 15=#f0f5f5
-palette = 16=#ff6a4b
-palette = 17=#e673a3
-palette = 18=#004f5e
-palette = 19=#006374
+palette = 0=#001c1f
+palette = 1=#d3464d
+palette = 2=#63b784
+palette = 3=#f3b863
+palette = 4=#568ccf
+palette = 5=#8b66d6
+palette = 6=#4fb7ae
+palette = 7=#d4e1e8
+palette = 8=#003640
+palette = 9=#d3464d
+palette = 10=#63b784
+palette = 11=#f3b863
+palette = 12=#568ccf
+palette = 13=#8b66d6
+palette = 14=#4fb7ae
+palette = 15=#f2f7f9
+palette = 16=#e37552
+palette = 17=#d0658e
+palette = 18=#002931
+palette = 19=#003640
 palette = 20=#0093a3
-palette = 21=#e6ebf0
+palette = 21=#e0e9ef
 
 # Foreground & background colors
-background = 003b46
-foreground = dce3e8
-cursor-color = dce3e8
-selection-background = 006374
-selection-foreground = dce3e8
+background = #001c1f
+foreground = #d4e1e8
+cursor-color = #d4e1e8
+selection-background = #003640
+selection-foreground = #d4e1e8
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = dce3e8
-macos-icon-screen-color = 003b46
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #f2f7f9
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #568ccf

--- a/themes/ghostty/base16-default-dark
+++ b/themes/ghostty/base16-default-dark
@@ -29,13 +29,15 @@ palette = 20=#b8b8b8
 palette = 21=#e8e8e8
 
 # Foreground & background colors
-background = 181818
-foreground = d8d8d8
-cursor-color = d8d8d8
-selection-background = 383838
-selection-foreground = d8d8d8
+background = #181818
+foreground = #d8d8d8
+cursor-color = #d8d8d8
+selection-background = #383838
+selection-foreground = #d8d8d8
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = d8d8d8
-macos-icon-screen-color = 181818
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #f8f8f8
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #7cafc2

--- a/themes/ghostty/base16-default-light
+++ b/themes/ghostty/base16-default-light
@@ -29,13 +29,15 @@ palette = 20=#585858
 palette = 21=#282828
 
 # Foreground & background colors
-background = f8f8f8
-foreground = 383838
-cursor-color = 383838
-selection-background = d8d8d8
-selection-foreground = 383838
+background = #f8f8f8
+foreground = #383838
+cursor-color = #383838
+selection-background = #d8d8d8
+selection-foreground = #383838
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 383838
-macos-icon-screen-color = f8f8f8
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #181818
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #7cafc2

--- a/themes/ghostty/base16-dirtysea
+++ b/themes/ghostty/base16-dirtysea
@@ -29,13 +29,15 @@ palette = 20=#202020
 palette = 21=#f8f8f8
 
 # Foreground & background colors
-background = e0e0e0
-foreground = 000000
-cursor-color = 000000
-selection-background = d0d0d0
-selection-foreground = 000000
+background = #e0e0e0
+foreground = #000000
+cursor-color = #000000
+selection-background = #d0d0d0
+selection-foreground = #000000
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 000000
-macos-icon-screen-color = e0e0e0
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #c4d9c4
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #007300

--- a/themes/ghostty/base16-dracula
+++ b/themes/ghostty/base16-dracula
@@ -29,13 +29,15 @@ palette = 20=#9ea8c7
 palette = 21=#f0f1f4
 
 # Foreground & background colors
-background = 282a36
-foreground = f8f8f2
-cursor-color = f8f8f2
-selection-background = 44475a
-selection-foreground = f8f8f2
+background = #282a36
+foreground = #f8f8f2
+cursor-color = #f8f8f2
+selection-background = #44475a
+selection-foreground = #f8f8f2
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = f8f8f2
-macos-icon-screen-color = 282a36
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #80bfff

--- a/themes/ghostty/base16-edge-dark
+++ b/themes/ghostty/base16-edge-dark
@@ -29,13 +29,15 @@ palette = 20=#73b3e7
 palette = 21=#d390e7
 
 # Foreground & background colors
-background = 262729
-foreground = b7bec9
-cursor-color = b7bec9
-selection-background = b7bec9
-selection-foreground = b7bec9
+background = #262729
+foreground = #b7bec9
+cursor-color = #b7bec9
+selection-background = #b7bec9
+selection-foreground = #b7bec9
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = b7bec9
-macos-icon-screen-color = 262729
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #3e4249
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #73b3e7

--- a/themes/ghostty/base16-edge-light
+++ b/themes/ghostty/base16-edge-light
@@ -29,13 +29,15 @@ palette = 20=#6587bf
 palette = 21=#b870ce
 
 # Foreground & background colors
-background = fafafa
-foreground = 5e646f
-cursor-color = 5e646f
-selection-background = d69822
-selection-foreground = 5e646f
+background = #fafafa
+foreground = #5e646f
+cursor-color = #5e646f
+selection-background = #d69822
+selection-foreground = #5e646f
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 5e646f
-macos-icon-screen-color = fafafa
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #5e646f
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #6587bf

--- a/themes/ghostty/base16-eighties
+++ b/themes/ghostty/base16-eighties
@@ -29,13 +29,15 @@ palette = 20=#a09f93
 palette = 21=#e8e6df
 
 # Foreground & background colors
-background = 2d2d2d
-foreground = d3d0c8
-cursor-color = d3d0c8
-selection-background = 515151
-selection-foreground = d3d0c8
+background = #2d2d2d
+foreground = #d3d0c8
+cursor-color = #d3d0c8
+selection-background = #515151
+selection-foreground = #d3d0c8
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = d3d0c8
-macos-icon-screen-color = 2d2d2d
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #f2f0ec
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #6699cc

--- a/themes/ghostty/base16-embers
+++ b/themes/ghostty/base16-embers
@@ -29,13 +29,15 @@ palette = 20=#8a8075
 palette = 21=#beb6ae
 
 # Foreground & background colors
-background = 16130f
-foreground = a39a90
-cursor-color = a39a90
-selection-background = 433b32
-selection-foreground = a39a90
+background = #16130f
+foreground = #a39a90
+cursor-color = #a39a90
+selection-background = #433b32
+selection-foreground = #a39a90
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = a39a90
-macos-icon-screen-color = 16130f
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #dbd6d1
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #6d5782

--- a/themes/ghostty/base16-embers-light
+++ b/themes/ghostty/base16-embers-light
@@ -29,13 +29,15 @@ palette = 20=#47505a
 palette = 21=#20262c
 
 # Foreground & background colors
-background = d1d6db
-foreground = 323b43
-cursor-color = 323b43
-selection-background = 909aa3
-selection-foreground = 323b43
+background = #d1d6db
+foreground = #323b43
+cursor-color = #323b43
+selection-background = #909aa3
+selection-foreground = #323b43
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 323b43
-macos-icon-screen-color = d1d6db
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #0f1316
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #82576d

--- a/themes/ghostty/base16-emil
+++ b/themes/ghostty/base16-emil
@@ -29,13 +29,15 @@ palette = 20=#505063
 palette = 21=#22223a
 
 # Foreground & background colors
-background = efefef
-foreground = 313145
-cursor-color = 313145
-selection-background = 9e9eaf
-selection-foreground = 313145
+background = #efefef
+foreground = #313145
+cursor-color = #313145
+selection-background = #9e9eaf
+selection-foreground = #313145
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 313145
-macos-icon-screen-color = efefef
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #1a1a2f
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #471397

--- a/themes/ghostty/base16-equilibrium-dark
+++ b/themes/ghostty/base16-equilibrium-dark
@@ -29,13 +29,15 @@ palette = 20=#949088
 palette = 21=#cac6bd
 
 # Foreground & background colors
-background = 0c1118
-foreground = afaba2
-cursor-color = afaba2
-selection-background = 22262d
-selection-foreground = afaba2
+background = #0c1118
+foreground = #afaba2
+cursor-color = #afaba2
+selection-background = #22262d
+selection-foreground = #afaba2
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = afaba2
-macos-icon-screen-color = 0c1118
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #e7e2d9
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #008dd1

--- a/themes/ghostty/base16-equilibrium-gray-dark
+++ b/themes/ghostty/base16-equilibrium-gray-dark
@@ -29,13 +29,15 @@ palette = 20=#919191
 palette = 21=#c6c6c6
 
 # Foreground & background colors
-background = 111111
-foreground = ababab
-cursor-color = ababab
-selection-background = 262626
-selection-foreground = ababab
+background = #111111
+foreground = #ababab
+cursor-color = #ababab
+selection-background = #262626
+selection-foreground = #ababab
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = ababab
-macos-icon-screen-color = 111111
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #e2e2e2
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #008dd1

--- a/themes/ghostty/base16-equilibrium-gray-light
+++ b/themes/ghostty/base16-equilibrium-gray-light
@@ -29,13 +29,15 @@ palette = 20=#5e5e5e
 palette = 21=#303030
 
 # Foreground & background colors
-background = f1f1f1
-foreground = 474747
-cursor-color = 474747
-selection-background = d4d4d4
-selection-foreground = 474747
+background = #f1f1f1
+foreground = #474747
+cursor-color = #474747
+selection-background = #d4d4d4
+selection-foreground = #474747
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 474747
-macos-icon-screen-color = f1f1f1
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #1b1b1b
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #0073b5

--- a/themes/ghostty/base16-equilibrium-light
+++ b/themes/ghostty/base16-equilibrium-light
@@ -29,13 +29,15 @@ palette = 20=#5a5f66
 palette = 21=#2c3138
 
 # Foreground & background colors
-background = f5f0e7
-foreground = 43474e
-cursor-color = 43474e
-selection-background = d8d4cb
-selection-foreground = 43474e
+background = #f5f0e7
+foreground = #43474e
+cursor-color = #43474e
+selection-background = #d8d4cb
+selection-foreground = #43474e
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 43474e
-macos-icon-screen-color = f5f0e7
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #181c22
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #0073b5

--- a/themes/ghostty/base16-eris
+++ b/themes/ghostty/base16-eris
@@ -29,13 +29,15 @@ palette = 20=#4a5293
 palette = 21=#7986c5
 
 # Foreground & background colors
-background = 0a0920
-foreground = 606bac
-cursor-color = 606bac
-selection-background = 23255a
-selection-foreground = 606bac
+background = #0a0920
+foreground = #606bac
+cursor-color = #606bac
+selection-background = #23255a
+selection-foreground = #606bac
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 606bac
-macos-icon-screen-color = 0a0920
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #9aaae5
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #258fc4

--- a/themes/ghostty/base16-espresso
+++ b/themes/ghostty/base16-espresso
@@ -29,13 +29,15 @@ palette = 20=#b4b7b4
 palette = 21=#e0e0e0
 
 # Foreground & background colors
-background = 2d2d2d
-foreground = cccccc
-cursor-color = cccccc
-selection-background = 515151
-selection-foreground = cccccc
+background = #2d2d2d
+foreground = #cccccc
+cursor-color = #cccccc
+selection-background = #515151
+selection-foreground = #cccccc
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = cccccc
-macos-icon-screen-color = 2d2d2d
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #6c99bb

--- a/themes/ghostty/base16-eva
+++ b/themes/ghostty/base16-eva
@@ -29,13 +29,15 @@ palette = 20=#7e90a3
 palette = 21=#d6d7d9
 
 # Foreground & background colors
-background = 2a3b4d
-foreground = 9fa2a6
-cursor-color = 9fa2a6
-selection-background = 4b6988
-selection-foreground = 9fa2a6
+background = #2a3b4d
+foreground = #9fa2a6
+cursor-color = #9fa2a6
+selection-background = #4b6988
+selection-foreground = #9fa2a6
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 9fa2a6
-macos-icon-screen-color = 2a3b4d
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #15f4ee

--- a/themes/ghostty/base16-eva-dim
+++ b/themes/ghostty/base16-eva-dim
@@ -29,13 +29,15 @@ palette = 20=#7e90a3
 palette = 21=#d6d7d9
 
 # Foreground & background colors
-background = 2a3b4d
-foreground = 9fa2a6
-cursor-color = 9fa2a6
-selection-background = 4b6988
-selection-foreground = 9fa2a6
+background = #2a3b4d
+foreground = #9fa2a6
+cursor-color = #9fa2a6
+selection-background = #4b6988
+selection-foreground = #9fa2a6
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 9fa2a6
-macos-icon-screen-color = 2a3b4d
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #1ae1dc

--- a/themes/ghostty/base16-evenok-dark
+++ b/themes/ghostty/base16-evenok-dark
@@ -29,13 +29,15 @@ palette = 20=#b0b0b0
 palette = 21=#e0e0e0
 
 # Foreground & background colors
-background = 000000
-foreground = d0d0d0
-cursor-color = d0d0d0
-selection-background = 303030
-selection-foreground = d0d0d0
+background = #000000
+foreground = #d0d0d0
+cursor-color = #d0d0d0
+selection-background = #303030
+selection-foreground = #d0d0d0
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = d0d0d0
-macos-icon-screen-color = 000000
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #00aff2

--- a/themes/ghostty/base16-everforest
+++ b/themes/ghostty/base16-everforest
@@ -29,13 +29,15 @@ palette = 20=#9da9a0
 palette = 21=#e6e2cc
 
 # Foreground & background colors
-background = 2d353b
-foreground = d3c6aa
-cursor-color = d3c6aa
-selection-background = 475258
-selection-foreground = d3c6aa
+background = #2d353b
+foreground = #d3c6aa
+cursor-color = #d3c6aa
+selection-background = #475258
+selection-foreground = #d3c6aa
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = d3c6aa
-macos-icon-screen-color = 2d353b
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #fdf6e3
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #7fbbb3

--- a/themes/ghostty/base16-everforest-dark-hard
+++ b/themes/ghostty/base16-everforest-dark-hard
@@ -29,13 +29,15 @@ palette = 20=#9da9a0
 palette = 21=#edeada
 
 # Foreground & background colors
-background = 272e33
-foreground = d3c6aa
-cursor-color = d3c6aa
-selection-background = 414b50
-selection-foreground = d3c6aa
+background = #272e33
+foreground = #d3c6aa
+cursor-color = #d3c6aa
+selection-background = #414b50
+selection-foreground = #d3c6aa
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = d3c6aa
-macos-icon-screen-color = 272e33
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #fffbef
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #7fbbb3

--- a/themes/ghostty/base16-flat
+++ b/themes/ghostty/base16-flat
@@ -29,13 +29,15 @@ palette = 20=#bdc3c7
 palette = 21=#f5f5f5
 
 # Foreground & background colors
-background = 2c3e50
-foreground = e0e0e0
-cursor-color = e0e0e0
-selection-background = 7f8c8d
-selection-foreground = e0e0e0
+background = #2c3e50
+foreground = #e0e0e0
+cursor-color = #e0e0e0
+selection-background = #7f8c8d
+selection-foreground = #e0e0e0
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = e0e0e0
-macos-icon-screen-color = 2c3e50
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ecf0f1
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #3498db

--- a/themes/ghostty/base16-framer
+++ b/themes/ghostty/base16-framer
@@ -29,13 +29,15 @@ palette = 20=#b9b9b9
 palette = 21=#e8e8e8
 
 # Foreground & background colors
-background = 181818
-foreground = d0d0d0
-cursor-color = d0d0d0
-selection-background = 464646
-selection-foreground = d0d0d0
+background = #181818
+foreground = #d0d0d0
+cursor-color = #d0d0d0
+selection-background = #464646
+selection-foreground = #d0d0d0
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = d0d0d0
-macos-icon-screen-color = 181818
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #eeeeee
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #20bcfc

--- a/themes/ghostty/base16-fruit-soda
+++ b/themes/ghostty/base16-fruit-soda
@@ -29,13 +29,15 @@ palette = 20=#979598
 palette = 21=#474545
 
 # Foreground & background colors
-background = f1ecf1
-foreground = 515151
-cursor-color = 515151
-selection-background = d8d5d5
-selection-foreground = 515151
+background = #f1ecf1
+foreground = #515151
+cursor-color = #515151
+selection-background = #d8d5d5
+selection-foreground = #515151
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 515151
-macos-icon-screen-color = f1ecf1
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #2d2c2c
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #2931df

--- a/themes/ghostty/base16-gigavolt
+++ b/themes/ghostty/base16-gigavolt
@@ -29,13 +29,15 @@ palette = 20=#cad3ff
 palette = 21=#eff0f9
 
 # Foreground & background colors
-background = 202126
-foreground = e9e7e1
-cursor-color = e9e7e1
-selection-background = 5a576e
-selection-foreground = e9e7e1
+background = #202126
+foreground = #e9e7e1
+cursor-color = #e9e7e1
+selection-background = #5a576e
+selection-foreground = #e9e7e1
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = e9e7e1
-macos-icon-screen-color = 202126
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #f2fbff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #40bfff

--- a/themes/ghostty/base16-github
+++ b/themes/ghostty/base16-github
@@ -29,13 +29,15 @@ palette = 20=#e8e8e8
 palette = 21=#ffffff
 
 # Foreground & background colors
-background = ffffff
-foreground = 333333
-cursor-color = 333333
-selection-background = c8c8fa
-selection-foreground = 333333
+background = #ffffff
+foreground = #333333
+cursor-color = #333333
+selection-background = #c8c8fa
+selection-foreground = #333333
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 333333
-macos-icon-screen-color = ffffff
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #795da3

--- a/themes/ghostty/base16-google-dark
+++ b/themes/ghostty/base16-google-dark
@@ -29,13 +29,15 @@ palette = 20=#b4b7b4
 palette = 21=#e0e0e0
 
 # Foreground & background colors
-background = 1d1f21
-foreground = c5c8c6
-cursor-color = c5c8c6
-selection-background = 373b41
-selection-foreground = c5c8c6
+background = #1d1f21
+foreground = #c5c8c6
+cursor-color = #c5c8c6
+selection-background = #373b41
+selection-foreground = #c5c8c6
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = c5c8c6
-macos-icon-screen-color = 1d1f21
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #3971ed

--- a/themes/ghostty/base16-google-light
+++ b/themes/ghostty/base16-google-light
@@ -29,13 +29,15 @@ palette = 20=#969896
 palette = 21=#282a2e
 
 # Foreground & background colors
-background = ffffff
-foreground = 373b41
-cursor-color = 373b41
-selection-background = c5c8c6
-selection-foreground = 373b41
+background = #ffffff
+foreground = #373b41
+cursor-color = #373b41
+selection-background = #c5c8c6
+selection-foreground = #373b41
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 373b41
-macos-icon-screen-color = ffffff
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #1d1f21
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #3971ed

--- a/themes/ghostty/base16-gotham
+++ b/themes/ghostty/base16-gotham
@@ -29,13 +29,15 @@ palette = 20=#245361
 palette = 21=#99d1ce
 
 # Foreground & background colors
-background = 0c1014
-foreground = 599cab
-cursor-color = 599cab
-selection-background = 091f2e
-selection-foreground = 599cab
+background = #0c1014
+foreground = #599cab
+cursor-color = #599cab
+selection-background = #091f2e
+selection-foreground = #599cab
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 599cab
-macos-icon-screen-color = 0c1014
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #d3ebe9
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #195466

--- a/themes/ghostty/base16-grayscale-dark
+++ b/themes/ghostty/base16-grayscale-dark
@@ -29,13 +29,15 @@ palette = 20=#ababab
 palette = 21=#e3e3e3
 
 # Foreground & background colors
-background = 101010
-foreground = b9b9b9
-cursor-color = b9b9b9
-selection-background = 464646
-selection-foreground = b9b9b9
+background = #101010
+foreground = #b9b9b9
+cursor-color = #b9b9b9
+selection-background = #464646
+selection-foreground = #b9b9b9
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = b9b9b9
-macos-icon-screen-color = 101010
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #f7f7f7
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #686868

--- a/themes/ghostty/base16-grayscale-light
+++ b/themes/ghostty/base16-grayscale-light
@@ -29,13 +29,15 @@ palette = 20=#525252
 palette = 21=#252525
 
 # Foreground & background colors
-background = f7f7f7
-foreground = 464646
-cursor-color = 464646
-selection-background = b9b9b9
-selection-foreground = 464646
+background = #f7f7f7
+foreground = #464646
+cursor-color = #464646
+selection-background = #b9b9b9
+selection-foreground = #464646
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 464646
-macos-icon-screen-color = f7f7f7
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #101010
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #686868

--- a/themes/ghostty/base16-greenscreen
+++ b/themes/ghostty/base16-greenscreen
@@ -29,13 +29,15 @@ palette = 20=#009900
 palette = 21=#00dd00
 
 # Foreground & background colors
-background = 001100
-foreground = 00bb00
-cursor-color = 00bb00
-selection-background = 005500
-selection-foreground = 00bb00
+background = #001100
+foreground = #00bb00
+cursor-color = #00bb00
+selection-background = #005500
+selection-foreground = #00bb00
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 00bb00
-macos-icon-screen-color = 001100
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #00ff00
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #009900

--- a/themes/ghostty/base16-gruber
+++ b/themes/ghostty/base16-gruber
@@ -29,13 +29,15 @@ palette = 20=#e4e4ef
 palette = 21=#f5f5f5
 
 # Foreground & background colors
-background = 181818
-foreground = f4f4ff
-cursor-color = f4f4ff
-selection-background = 484848
-selection-foreground = f4f4ff
+background = #181818
+foreground = #f4f4ff
+cursor-color = #f4f4ff
+selection-background = #484848
+selection-foreground = #f4f4ff
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = f4f4ff
-macos-icon-screen-color = 181818
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #e4e4ef
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #96a6c8

--- a/themes/ghostty/base16-gruvbox-dark-hard
+++ b/themes/ghostty/base16-gruvbox-dark-hard
@@ -29,13 +29,15 @@ palette = 20=#bdae93
 palette = 21=#ebdbb2
 
 # Foreground & background colors
-background = 1d2021
-foreground = d5c4a1
-cursor-color = d5c4a1
-selection-background = 504945
-selection-foreground = d5c4a1
+background = #1d2021
+foreground = #d5c4a1
+cursor-color = #d5c4a1
+selection-background = #504945
+selection-foreground = #d5c4a1
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = d5c4a1
-macos-icon-screen-color = 1d2021
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #fbf1c7
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #83a598

--- a/themes/ghostty/base16-gruvbox-dark-medium
+++ b/themes/ghostty/base16-gruvbox-dark-medium
@@ -29,13 +29,15 @@ palette = 20=#bdae93
 palette = 21=#ebdbb2
 
 # Foreground & background colors
-background = 282828
-foreground = d5c4a1
-cursor-color = d5c4a1
-selection-background = 504945
-selection-foreground = d5c4a1
+background = #282828
+foreground = #d5c4a1
+cursor-color = #d5c4a1
+selection-background = #504945
+selection-foreground = #d5c4a1
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = d5c4a1
-macos-icon-screen-color = 282828
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #fbf1c7
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #83a598

--- a/themes/ghostty/base16-gruvbox-dark-pale
+++ b/themes/ghostty/base16-gruvbox-dark-pale
@@ -29,13 +29,15 @@ palette = 20=#949494
 palette = 21=#d5c4a1
 
 # Foreground & background colors
-background = 262626
-foreground = dab997
-cursor-color = dab997
-selection-background = 4e4e4e
-selection-foreground = dab997
+background = #262626
+foreground = #dab997
+cursor-color = #dab997
+selection-background = #4e4e4e
+selection-foreground = #dab997
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = dab997
-macos-icon-screen-color = 262626
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ebdbb2
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #83adad

--- a/themes/ghostty/base16-gruvbox-dark-soft
+++ b/themes/ghostty/base16-gruvbox-dark-soft
@@ -29,13 +29,15 @@ palette = 20=#bdae93
 palette = 21=#ebdbb2
 
 # Foreground & background colors
-background = 32302f
-foreground = d5c4a1
-cursor-color = d5c4a1
-selection-background = 504945
-selection-foreground = d5c4a1
+background = #32302f
+foreground = #d5c4a1
+cursor-color = #d5c4a1
+selection-background = #504945
+selection-foreground = #d5c4a1
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = d5c4a1
-macos-icon-screen-color = 32302f
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #fbf1c7
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #83a598

--- a/themes/ghostty/base16-gruvbox-light-hard
+++ b/themes/ghostty/base16-gruvbox-light-hard
@@ -29,13 +29,15 @@ palette = 20=#665c54
 palette = 21=#3c3836
 
 # Foreground & background colors
-background = f9f5d7
-foreground = 504945
-cursor-color = 504945
-selection-background = d5c4a1
-selection-foreground = 504945
+background = #f9f5d7
+foreground = #504945
+cursor-color = #504945
+selection-background = #d5c4a1
+selection-foreground = #504945
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 504945
-macos-icon-screen-color = f9f5d7
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #282828
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #076678

--- a/themes/ghostty/base16-gruvbox-light-medium
+++ b/themes/ghostty/base16-gruvbox-light-medium
@@ -29,13 +29,15 @@ palette = 20=#665c54
 palette = 21=#3c3836
 
 # Foreground & background colors
-background = fbf1c7
-foreground = 504945
-cursor-color = 504945
-selection-background = d5c4a1
-selection-foreground = 504945
+background = #fbf1c7
+foreground = #504945
+cursor-color = #504945
+selection-background = #d5c4a1
+selection-foreground = #504945
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 504945
-macos-icon-screen-color = fbf1c7
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #282828
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #076678

--- a/themes/ghostty/base16-gruvbox-light-soft
+++ b/themes/ghostty/base16-gruvbox-light-soft
@@ -29,13 +29,15 @@ palette = 20=#665c54
 palette = 21=#3c3836
 
 # Foreground & background colors
-background = f2e5bc
-foreground = 504945
-cursor-color = 504945
-selection-background = d5c4a1
-selection-foreground = 504945
+background = #f2e5bc
+foreground = #504945
+cursor-color = #504945
+selection-background = #d5c4a1
+selection-foreground = #504945
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 504945
-macos-icon-screen-color = f2e5bc
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #282828
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #076678

--- a/themes/ghostty/base16-gruvbox-material-dark-hard
+++ b/themes/ghostty/base16-gruvbox-material-dark-hard
@@ -29,13 +29,15 @@ palette = 20=#bdae93
 palette = 21=#ebdbb2
 
 # Foreground & background colors
-background = 202020
-foreground = ddc7a1
-cursor-color = ddc7a1
-selection-background = 504945
-selection-foreground = ddc7a1
+background = #202020
+foreground = #ddc7a1
+cursor-color = #ddc7a1
+selection-background = #504945
+selection-foreground = #ddc7a1
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = ddc7a1
-macos-icon-screen-color = 202020
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #fbf1c7
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #7daea3

--- a/themes/ghostty/base16-gruvbox-material-dark-medium
+++ b/themes/ghostty/base16-gruvbox-material-dark-medium
@@ -29,13 +29,15 @@ palette = 20=#bdae93
 palette = 21=#ebdbb2
 
 # Foreground & background colors
-background = 292828
-foreground = ddc7a1
-cursor-color = ddc7a1
-selection-background = 504945
-selection-foreground = ddc7a1
+background = #292828
+foreground = #ddc7a1
+cursor-color = #ddc7a1
+selection-background = #504945
+selection-foreground = #ddc7a1
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = ddc7a1
-macos-icon-screen-color = 292828
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #fbf1c7
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #7daea3

--- a/themes/ghostty/base16-gruvbox-material-dark-soft
+++ b/themes/ghostty/base16-gruvbox-material-dark-soft
@@ -29,13 +29,15 @@ palette = 20=#bdae93
 palette = 21=#ebdbb2
 
 # Foreground & background colors
-background = 32302f
-foreground = ddc7a1
-cursor-color = ddc7a1
-selection-background = 5a524c
-selection-foreground = ddc7a1
+background = #32302f
+foreground = #ddc7a1
+cursor-color = #ddc7a1
+selection-background = #5a524c
+selection-foreground = #ddc7a1
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = ddc7a1
-macos-icon-screen-color = 32302f
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #fbf1c7
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #7daea3

--- a/themes/ghostty/base16-gruvbox-material-light-hard
+++ b/themes/ghostty/base16-gruvbox-material-light-hard
@@ -29,13 +29,15 @@ palette = 20=#c9b99a
 palette = 21=#3c3836
 
 # Foreground & background colors
-background = f9f5d7
-foreground = 654735
-cursor-color = 654735
-selection-background = e0cfa9
-selection-foreground = 654735
+background = #f9f5d7
+foreground = #654735
+cursor-color = #654735
+selection-background = #e0cfa9
+selection-foreground = #654735
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 654735
-macos-icon-screen-color = f9f5d7
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #282828
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #45707a

--- a/themes/ghostty/base16-gruvbox-material-light-medium
+++ b/themes/ghostty/base16-gruvbox-material-light-medium
@@ -29,13 +29,15 @@ palette = 20=#665c54
 palette = 21=#3c3836
 
 # Foreground & background colors
-background = fbf1c7
-foreground = 654735
-cursor-color = 654735
-selection-background = d5c4a1
-selection-foreground = 654735
+background = #fbf1c7
+foreground = #654735
+cursor-color = #654735
+selection-background = #d5c4a1
+selection-foreground = #654735
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 654735
-macos-icon-screen-color = fbf1c7
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #282828
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #45707a

--- a/themes/ghostty/base16-gruvbox-material-light-soft
+++ b/themes/ghostty/base16-gruvbox-material-light-soft
@@ -29,13 +29,15 @@ palette = 20=#665c54
 palette = 21=#3c3836
 
 # Foreground & background colors
-background = f2e5bc
-foreground = 654735
-cursor-color = 654735
-selection-background = c9b99a
-selection-foreground = 654735
+background = #f2e5bc
+foreground = #654735
+cursor-color = #654735
+selection-background = #c9b99a
+selection-foreground = #654735
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 654735
-macos-icon-screen-color = f2e5bc
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #282828
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #45707a

--- a/themes/ghostty/base16-hardcore
+++ b/themes/ghostty/base16-hardcore
@@ -29,13 +29,15 @@ palette = 20=#707070
 palette = 21=#e5e5e5
 
 # Foreground & background colors
-background = 212121
-foreground = cdcdcd
-cursor-color = cdcdcd
-selection-background = 353535
-selection-foreground = cdcdcd
+background = #212121
+foreground = #cdcdcd
+cursor-color = #cdcdcd
+selection-background = #353535
+selection-foreground = #cdcdcd
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = cdcdcd
-macos-icon-screen-color = 212121
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #66d9ef

--- a/themes/ghostty/base16-harmonic16-dark
+++ b/themes/ghostty/base16-harmonic16-dark
@@ -29,13 +29,15 @@ palette = 20=#aabcce
 palette = 21=#e5ebf1
 
 # Foreground & background colors
-background = 0b1c2c
-foreground = cbd6e2
-cursor-color = cbd6e2
-selection-background = 405c79
-selection-foreground = cbd6e2
+background = #0b1c2c
+foreground = #cbd6e2
+cursor-color = #cbd6e2
+selection-background = #405c79
+selection-foreground = #cbd6e2
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = cbd6e2
-macos-icon-screen-color = 0b1c2c
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #f7f9fb
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #8b56bf

--- a/themes/ghostty/base16-harmonic16-light
+++ b/themes/ghostty/base16-harmonic16-light
@@ -29,13 +29,15 @@ palette = 20=#627e99
 palette = 21=#223b54
 
 # Foreground & background colors
-background = f7f9fb
-foreground = 405c79
-cursor-color = 405c79
-selection-background = cbd6e2
-selection-foreground = 405c79
+background = #f7f9fb
+foreground = #405c79
+cursor-color = #405c79
+selection-background = #cbd6e2
+selection-foreground = #405c79
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 405c79
-macos-icon-screen-color = f7f9fb
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #0b1c2c
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #8b56bf

--- a/themes/ghostty/base16-heetch
+++ b/themes/ghostty/base16-heetch
@@ -29,13 +29,15 @@ palette = 20=#9c92a8
 palette = 21=#dedae2
 
 # Foreground & background colors
-background = 190134
-foreground = bdb6c5
-cursor-color = bdb6c5
-selection-background = 5a496e
-selection-foreground = bdb6c5
+background = #190134
+foreground = #bdb6c5
+cursor-color = #bdb6c5
+selection-background = #5a496e
+selection-foreground = #bdb6c5
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = bdb6c5
-macos-icon-screen-color = 190134
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #feffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #bd0152

--- a/themes/ghostty/base16-heetch-light
+++ b/themes/ghostty/base16-heetch-light
@@ -29,13 +29,15 @@ palette = 20=#ddd6e5
 palette = 21=#470546
 
 # Foreground & background colors
-background = feffff
-foreground = 5a496e
-cursor-color = 5a496e
-selection-background = 7b6d8b
-selection-foreground = 5a496e
+background = #feffff
+foreground = #5a496e
+cursor-color = #5a496e
+selection-background = #7b6d8b
+selection-foreground = #5a496e
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 5a496e
-macos-icon-screen-color = feffff
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #190134
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #47f9f5

--- a/themes/ghostty/base16-helios
+++ b/themes/ghostty/base16-helios
@@ -29,13 +29,15 @@ palette = 20=#cdcdcd
 palette = 21=#dddddd
 
 # Foreground & background colors
-background = 1d2021
-foreground = d5d5d5
-cursor-color = d5d5d5
-selection-background = 53585b
-selection-foreground = d5d5d5
+background = #1d2021
+foreground = #d5d5d5
+cursor-color = #d5d5d5
+selection-background = #53585b
+selection-foreground = #d5d5d5
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = d5d5d5
-macos-icon-screen-color = 1d2021
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #e5e5e5
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #1e8bac

--- a/themes/ghostty/base16-hopscotch
+++ b/themes/ghostty/base16-hopscotch
@@ -29,13 +29,15 @@ palette = 20=#989498
 palette = 21=#d5d3d5
 
 # Foreground & background colors
-background = 322931
-foreground = b9b5b8
-cursor-color = b9b5b8
-selection-background = 5c545b
-selection-foreground = b9b5b8
+background = #322931
+foreground = #b9b5b8
+cursor-color = #b9b5b8
+selection-background = #5c545b
+selection-foreground = #b9b5b8
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = b9b5b8
-macos-icon-screen-color = 322931
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #1290bf

--- a/themes/ghostty/base16-horizon-dark
+++ b/themes/ghostty/base16-horizon-dark
@@ -29,13 +29,15 @@ palette = 20=#9da0a2
 palette = 21=#dcdfe4
 
 # Foreground & background colors
-background = 1c1e26
-foreground = cbced0
-cursor-color = cbced0
-selection-background = 2e303e
-selection-foreground = cbced0
+background = #1c1e26
+foreground = #cbced0
+cursor-color = #cbced0
+selection-background = #2e303e
+selection-foreground = #cbced0
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = cbced0
-macos-icon-screen-color = 1c1e26
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #e3e6ee
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #df5273

--- a/themes/ghostty/base16-horizon-light
+++ b/themes/ghostty/base16-horizon-light
@@ -29,13 +29,15 @@ palette = 20=#948c8a
 palette = 21=#302c2d
 
 # Foreground & background colors
-background = fdf0ed
-foreground = 403c3d
-cursor-color = 403c3d
-selection-background = f9cbbe
-selection-foreground = 403c3d
+background = #fdf0ed
+foreground = #403c3d
+cursor-color = #403c3d
+selection-background = #f9cbbe
+selection-foreground = #403c3d
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 403c3d
-macos-icon-screen-color = fdf0ed
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #201c1d
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #da103f

--- a/themes/ghostty/base16-horizon-terminal-dark
+++ b/themes/ghostty/base16-horizon-terminal-dark
@@ -29,13 +29,15 @@ palette = 20=#9da0a2
 palette = 21=#dcdfe4
 
 # Foreground & background colors
-background = 1c1e26
-foreground = cbced0
-cursor-color = cbced0
-selection-background = 2e303e
-selection-foreground = cbced0
+background = #1c1e26
+foreground = #cbced0
+cursor-color = #cbced0
+selection-background = #2e303e
+selection-foreground = #cbced0
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = cbced0
-macos-icon-screen-color = 1c1e26
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #e3e6ee
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #26bbd9

--- a/themes/ghostty/base16-horizon-terminal-light
+++ b/themes/ghostty/base16-horizon-terminal-light
@@ -29,13 +29,15 @@ palette = 20=#948c8a
 palette = 21=#302c2d
 
 # Foreground & background colors
-background = fdf0ed
-foreground = 403c3d
-cursor-color = 403c3d
-selection-background = f9cbbe
-selection-foreground = 403c3d
+background = #fdf0ed
+foreground = #403c3d
+cursor-color = #403c3d
+selection-background = #f9cbbe
+selection-foreground = #403c3d
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 403c3d
-macos-icon-screen-color = fdf0ed
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #201c1d
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #26bbd9

--- a/themes/ghostty/base16-humanoid-dark
+++ b/themes/ghostty/base16-humanoid-dark
@@ -29,13 +29,15 @@ palette = 20=#c0c0bd
 palette = 21=#fcfcf6
 
 # Foreground & background colors
-background = 232629
-foreground = f8f8f2
-cursor-color = f8f8f2
-selection-background = 484e54
-selection-foreground = f8f8f2
+background = #232629
+foreground = #f8f8f2
+cursor-color = #f8f8f2
+selection-background = #484e54
+selection-foreground = #f8f8f2
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = f8f8f2
-macos-icon-screen-color = 232629
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #fcfcfc
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #00a6fb

--- a/themes/ghostty/base16-humanoid-light
+++ b/themes/ghostty/base16-humanoid-light
@@ -29,13 +29,15 @@ palette = 20=#60615d
 palette = 21=#2f3337
 
 # Foreground & background colors
-background = f8f8f2
-foreground = 232629
-cursor-color = 232629
-selection-background = deded8
-selection-foreground = 232629
+background = #f8f8f2
+foreground = #232629
+cursor-color = #232629
+selection-background = #deded8
+selection-foreground = #232629
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 232629
-macos-icon-screen-color = f8f8f2
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #070708
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #0082c9

--- a/themes/ghostty/base16-ia-dark
+++ b/themes/ghostty/base16-ia-dark
@@ -29,13 +29,15 @@ palette = 20=#b8b8b8
 palette = 21=#e8e8e8
 
 # Foreground & background colors
-background = 1a1a1a
-foreground = cccccc
-cursor-color = cccccc
-selection-background = 1d414d
-selection-foreground = cccccc
+background = #1a1a1a
+foreground = #cccccc
+cursor-color = #cccccc
+selection-background = #1d414d
+selection-foreground = #cccccc
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = cccccc
-macos-icon-screen-color = 1a1a1a
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #f8f8f8
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #8eccdd

--- a/themes/ghostty/base16-ia-light
+++ b/themes/ghostty/base16-ia-light
@@ -29,13 +29,15 @@ palette = 20=#767676
 palette = 21=#e8e8e8
 
 # Foreground & background colors
-background = f6f6f6
-foreground = 181818
-cursor-color = 181818
-selection-background = bde5f2
-selection-foreground = 181818
+background = #f6f6f6
+foreground = #181818
+cursor-color = #181818
+selection-background = #bde5f2
+selection-foreground = #181818
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 181818
-macos-icon-screen-color = f6f6f6
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #f8f8f8
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #48bac2

--- a/themes/ghostty/base16-icy
+++ b/themes/ghostty/base16-icy
@@ -29,13 +29,15 @@ palette = 20=#064048
 palette = 21=#0c7c8c
 
 # Foreground & background colors
-background = 021012
-foreground = 095b67
-cursor-color = 095b67
-selection-background = 041f23
-selection-foreground = 095b67
+background = #021012
+foreground = #095b67
+cursor-color = #095b67
+selection-background = #041f23
+selection-foreground = #095b67
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 095b67
-macos-icon-screen-color = 021012
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #109cb0
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #00bcd4

--- a/themes/ghostty/base16-irblack
+++ b/themes/ghostty/base16-irblack
@@ -29,13 +29,15 @@ palette = 20=#918f88
 palette = 21=#d9d7cc
 
 # Foreground & background colors
-background = 000000
-foreground = b5b3aa
-cursor-color = b5b3aa
-selection-background = 484844
-selection-foreground = b5b3aa
+background = #000000
+foreground = #b5b3aa
+cursor-color = #b5b3aa
+selection-background = #484844
+selection-foreground = #b5b3aa
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = b5b3aa
-macos-icon-screen-color = 000000
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #fdfbee
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #96cbfe

--- a/themes/ghostty/base16-isotope
+++ b/themes/ghostty/base16-isotope
@@ -29,13 +29,15 @@ palette = 20=#c0c0c0
 palette = 21=#e0e0e0
 
 # Foreground & background colors
-background = 000000
-foreground = d0d0d0
-cursor-color = d0d0d0
-selection-background = 606060
-selection-foreground = d0d0d0
+background = #000000
+foreground = #d0d0d0
+cursor-color = #d0d0d0
+selection-background = #606060
+selection-foreground = #d0d0d0
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = d0d0d0
-macos-icon-screen-color = 000000
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #0066ff

--- a/themes/ghostty/base16-jabuti
+++ b/themes/ghostty/base16-jabuti
@@ -29,13 +29,15 @@ palette = 20=#50526b
 palette = 21=#d9e0ee
 
 # Foreground & background colors
-background = 292a37
-foreground = c0cbe3
-cursor-color = c0cbe3
-selection-background = 3c3e51
-selection-foreground = c0cbe3
+background = #292a37
+foreground = #c0cbe3
+cursor-color = #c0cbe3
+selection-background = #3c3e51
+selection-foreground = #c0cbe3
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = c0cbe3
-macos-icon-screen-color = 292a37
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #3fc6de

--- a/themes/ghostty/base16-kanagawa
+++ b/themes/ghostty/base16-kanagawa
@@ -29,13 +29,15 @@ palette = 20=#727169
 palette = 21=#c8c093
 
 # Foreground & background colors
-background = 1f1f28
-foreground = dcd7ba
-cursor-color = dcd7ba
-selection-background = 223249
-selection-foreground = dcd7ba
+background = #1f1f28
+foreground = #dcd7ba
+cursor-color = #dcd7ba
+selection-background = #223249
+selection-foreground = #dcd7ba
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = dcd7ba
-macos-icon-screen-color = 1f1f28
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #717c7c
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #7e9cd8

--- a/themes/ghostty/base16-katy
+++ b/themes/ghostty/base16-katy
@@ -29,13 +29,15 @@ palette = 20=#8796b0
 palette = 21=#959dcb
 
 # Foreground & background colors
-background = 292d3e
-foreground = 959dcb
-cursor-color = 959dcb
-selection-background = 5c598b
-selection-foreground = 959dcb
+background = #292d3e
+foreground = #959dcb
+cursor-color = #959dcb
+selection-background = #5c598b
+selection-foreground = #959dcb
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 959dcb
-macos-icon-screen-color = 292d3e
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #82aaff

--- a/themes/ghostty/base16-kimber
+++ b/themes/ghostty/base16-kimber
@@ -29,13 +29,15 @@ palette = 20=#5a5a5a
 palette = 21=#c3c3b4
 
 # Foreground & background colors
-background = 222222
-foreground = dedee7
-cursor-color = dedee7
-selection-background = 555d55
-selection-foreground = dedee7
+background = #222222
+foreground = #dedee7
+cursor-color = #dedee7
+selection-background = #555d55
+selection-foreground = #dedee7
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = dedee7
-macos-icon-screen-color = 222222
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffe6
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #537c9c

--- a/themes/ghostty/base16-lime
+++ b/themes/ghostty/base16-lime
@@ -29,13 +29,15 @@ palette = 20=#515155
 palette = 21=#fff2d1
 
 # Foreground & background colors
-background = 1a1a2f
-foreground = 818175
-cursor-color = 818175
-selection-background = 2a2a3f
-selection-foreground = 818175
+background = #1a1a2f
+foreground = #818175
+cursor-color = #818175
+selection-background = #2a2a3f
+selection-foreground = #818175
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 818175
-macos-icon-screen-color = 1a1a2f
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #fff8e1
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #2b926f

--- a/themes/ghostty/base16-macintosh
+++ b/themes/ghostty/base16-macintosh
@@ -29,13 +29,15 @@ palette = 20=#808080
 palette = 21=#c0c0c0
 
 # Foreground & background colors
-background = 000000
-foreground = c0c0c0
-cursor-color = c0c0c0
-selection-background = 404040
-selection-foreground = c0c0c0
+background = #000000
+foreground = #c0c0c0
+cursor-color = #c0c0c0
+selection-background = #404040
+selection-foreground = #c0c0c0
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = c0c0c0
-macos-icon-screen-color = 000000
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #0000d3

--- a/themes/ghostty/base16-marrakesh
+++ b/themes/ghostty/base16-marrakesh
@@ -29,13 +29,15 @@ palette = 20=#86813b
 palette = 21=#ccc37a
 
 # Foreground & background colors
-background = 201602
-foreground = 948e48
-cursor-color = 948e48
-selection-background = 5f5b17
-selection-foreground = 948e48
+background = #201602
+foreground = #948e48
+cursor-color = #948e48
+selection-background = #5f5b17
+selection-foreground = #948e48
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 948e48
-macos-icon-screen-color = 201602
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #faf0a5
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #477ca1

--- a/themes/ghostty/base16-materia
+++ b/themes/ghostty/base16-materia
@@ -29,13 +29,15 @@ palette = 20=#c9ccd3
 palette = 21=#d5dbe5
 
 # Foreground & background colors
-background = 263238
-foreground = cdd3de
-cursor-color = cdd3de
-selection-background = 37474f
-selection-foreground = cdd3de
+background = #263238
+foreground = #cdd3de
+cursor-color = #cdd3de
+selection-background = #37474f
+selection-foreground = #cdd3de
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = cdd3de
-macos-icon-screen-color = 263238
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #89ddff

--- a/themes/ghostty/base16-material
+++ b/themes/ghostty/base16-material
@@ -29,13 +29,15 @@ palette = 20=#b2ccd6
 palette = 21=#eeffff
 
 # Foreground & background colors
-background = 263238
-foreground = eeffff
-cursor-color = eeffff
-selection-background = 314549
-selection-foreground = eeffff
+background = #263238
+foreground = #eeffff
+cursor-color = #eeffff
+selection-background = #314549
+selection-foreground = #eeffff
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = eeffff
-macos-icon-screen-color = 263238
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #82aaff

--- a/themes/ghostty/base16-material-darker
+++ b/themes/ghostty/base16-material-darker
@@ -29,13 +29,15 @@ palette = 20=#b2ccd6
 palette = 21=#eeffff
 
 # Foreground & background colors
-background = 212121
-foreground = eeffff
-cursor-color = eeffff
-selection-background = 353535
-selection-foreground = eeffff
+background = #212121
+foreground = #eeffff
+cursor-color = #eeffff
+selection-background = #353535
+selection-foreground = #eeffff
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = eeffff
-macos-icon-screen-color = 212121
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #82aaff

--- a/themes/ghostty/base16-material-lighter
+++ b/themes/ghostty/base16-material-lighter
@@ -29,13 +29,15 @@ palette = 20=#8796b0
 palette = 21=#80cbc4
 
 # Foreground & background colors
-background = fafafa
-foreground = 80cbc4
-cursor-color = 80cbc4
-selection-background = cceae7
-selection-foreground = 80cbc4
+background = #fafafa
+foreground = #80cbc4
+cursor-color = #80cbc4
+selection-background = #cceae7
+selection-foreground = #80cbc4
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 80cbc4
-macos-icon-screen-color = fafafa
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #6182b8

--- a/themes/ghostty/base16-material-palenight
+++ b/themes/ghostty/base16-material-palenight
@@ -29,13 +29,15 @@ palette = 20=#8796b0
 palette = 21=#959dcb
 
 # Foreground & background colors
-background = 292d3e
-foreground = 959dcb
-cursor-color = 959dcb
-selection-background = 32374d
-selection-foreground = 959dcb
+background = #292d3e
+foreground = #959dcb
+cursor-color = #959dcb
+selection-background = #32374d
+selection-foreground = #959dcb
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 959dcb
-macos-icon-screen-color = 292d3e
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #82aaff

--- a/themes/ghostty/base16-material-vivid
+++ b/themes/ghostty/base16-material-vivid
@@ -29,13 +29,15 @@ palette = 20=#676c71
 palette = 21=#9e9e9e
 
 # Foreground & background colors
-background = 202124
-foreground = 80868b
-cursor-color = 80868b
-selection-background = 323639
-selection-foreground = 80868b
+background = #202124
+foreground = #80868b
+cursor-color = #80868b
+selection-background = #323639
+selection-foreground = #80868b
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 80868b
-macos-icon-screen-color = 202124
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #2196f3

--- a/themes/ghostty/base16-measured-dark
+++ b/themes/ghostty/base16-measured-dark
@@ -29,13 +29,15 @@ palette = 20=#c3c3c3
 palette = 21=#efefef
 
 # Foreground & background colors
-background = 00211f
-foreground = dcdcdc
-cursor-color = dcdcdc
-selection-background = 005453
-selection-foreground = dcdcdc
+background = #00211f
+foreground = #dcdcdc
+cursor-color = #dcdcdc
+selection-background = #005453
+selection-foreground = #dcdcdc
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = dcdcdc
-macos-icon-screen-color = 00211f
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #f5f5f5
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #88b0da

--- a/themes/ghostty/base16-measured-light
+++ b/themes/ghostty/base16-measured-light
@@ -29,13 +29,15 @@ palette = 20=#404040
 palette = 21=#181818
 
 # Foreground & background colors
-background = fdf9f5
-foreground = 292929
-cursor-color = 292929
-selection-background = ffeada
-selection-foreground = 292929
+background = #fdf9f5
+foreground = #292929
+cursor-color = #292929
+selection-background = #ffeada
+selection-foreground = #292929
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 292929
-macos-icon-screen-color = fdf9f5
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #000000
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #0158ad

--- a/themes/ghostty/base16-mellow-purple
+++ b/themes/ghostty/base16-mellow-purple
@@ -29,13 +29,15 @@ palette = 20=#873582
 palette = 21=#ffeeff
 
 # Foreground & background colors
-background = 1e0528
-foreground = ffeeff
-cursor-color = ffeeff
-selection-background = 331354
-selection-foreground = ffeeff
+background = #1e0528
+foreground = #ffeeff
+cursor-color = #ffeeff
+selection-background = #331354
+selection-foreground = #ffeeff
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = ffeeff
-macos-icon-screen-color = 1e0528
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #f8c0ff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #550068

--- a/themes/ghostty/base16-mexico-light
+++ b/themes/ghostty/base16-mexico-light
@@ -29,13 +29,15 @@ palette = 20=#585858
 palette = 21=#282828
 
 # Foreground & background colors
-background = f8f8f8
-foreground = 383838
-cursor-color = 383838
-selection-background = d8d8d8
-selection-foreground = 383838
+background = #f8f8f8
+foreground = #383838
+cursor-color = #383838
+selection-background = #d8d8d8
+selection-foreground = #383838
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 383838
-macos-icon-screen-color = f8f8f8
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #181818
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #7cafc2

--- a/themes/ghostty/base16-mocha
+++ b/themes/ghostty/base16-mocha
@@ -29,13 +29,15 @@ palette = 20=#b8afad
 palette = 21=#e9e1dd
 
 # Foreground & background colors
-background = 3b3228
-foreground = d0c8c6
-cursor-color = d0c8c6
-selection-background = 645240
-selection-foreground = d0c8c6
+background = #3b3228
+foreground = #d0c8c6
+cursor-color = #d0c8c6
+selection-background = #645240
+selection-foreground = #d0c8c6
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = d0c8c6
-macos-icon-screen-color = 3b3228
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #f5eeeb
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #8ab3b5

--- a/themes/ghostty/base16-monokai
+++ b/themes/ghostty/base16-monokai
@@ -29,13 +29,15 @@ palette = 20=#a59f85
 palette = 21=#f5f4f1
 
 # Foreground & background colors
-background = 272822
-foreground = f8f8f2
-cursor-color = f8f8f2
-selection-background = 49483e
-selection-foreground = f8f8f2
+background = #272822
+foreground = #f8f8f2
+cursor-color = #f8f8f2
+selection-background = #49483e
+selection-foreground = #f8f8f2
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = f8f8f2
-macos-icon-screen-color = 272822
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #f9f8f5
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #66d9ef

--- a/themes/ghostty/base16-moonlight
+++ b/themes/ghostty/base16-moonlight
@@ -29,13 +29,15 @@ palette = 20=#a1abe0
 palette = 21=#b4a4f4
 
 # Foreground & background colors
-background = 212337
-foreground = a3ace1
-cursor-color = a3ace1
-selection-background = 596399
-selection-foreground = a3ace1
+background = #212337
+foreground = #a3ace1
+cursor-color = #a3ace1
+selection-background = #596399
+selection-foreground = #a3ace1
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = a3ace1
-macos-icon-screen-color = 212337
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ef43fa
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #40ffff

--- a/themes/ghostty/base16-mountain
+++ b/themes/ghostty/base16-mountain
@@ -29,13 +29,15 @@ palette = 20=#ac8a8c
 palette = 21=#e7e7e7
 
 # Foreground & background colors
-background = 0f0f0f
-foreground = cacaca
-cursor-color = cacaca
-selection-background = 262626
-selection-foreground = cacaca
+background = #0f0f0f
+foreground = #cacaca
+cursor-color = #cacaca
+selection-background = #262626
+selection-foreground = #cacaca
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = cacaca
-macos-icon-screen-color = 0f0f0f
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #f0f0f0
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #8f8aac

--- a/themes/ghostty/base16-nebula
+++ b/themes/ghostty/base16-nebula
@@ -29,13 +29,15 @@ palette = 20=#87888b
 palette = 21=#c7c9cd
 
 # Foreground & background colors
-background = 22273b
-foreground = a4a6a9
-cursor-color = a4a6a9
-selection-background = 5a8380
-selection-foreground = a4a6a9
+background = #22273b
+foreground = #a4a6a9
+cursor-color = #a4a6a9
+selection-background = #5a8380
+selection-foreground = #a4a6a9
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = a4a6a9
-macos-icon-screen-color = 22273b
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #8dbdaa
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #4d6bb6

--- a/themes/ghostty/base16-nord
+++ b/themes/ghostty/base16-nord
@@ -29,13 +29,15 @@ palette = 20=#d8dee9
 palette = 21=#eceff4
 
 # Foreground & background colors
-background = 2e3440
-foreground = e5e9f0
-cursor-color = e5e9f0
-selection-background = 434c5e
-selection-foreground = e5e9f0
+background = #2e3440
+foreground = #e5e9f0
+cursor-color = #e5e9f0
+selection-background = #434c5e
+selection-foreground = #e5e9f0
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = e5e9f0
-macos-icon-screen-color = 2e3440
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #8fbcbb
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #81a1c1

--- a/themes/ghostty/base16-nord-light
+++ b/themes/ghostty/base16-nord-light
@@ -29,13 +29,15 @@ palette = 20=#60728c
 palette = 21=#3b4252
 
 # Foreground & background colors
-background = e5e9f0
-foreground = 2e3440
-cursor-color = 2e3440
-selection-background = b8c5db
-selection-foreground = 2e3440
+background = #e5e9f0
+foreground = #2e3440
+cursor-color = #2e3440
+selection-background = #b8c5db
+selection-foreground = #2e3440
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 2e3440
-macos-icon-screen-color = e5e9f0
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #29838d
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #3b6ea8

--- a/themes/ghostty/base16-nova
+++ b/themes/ghostty/base16-nova
@@ -29,13 +29,15 @@ palette = 20=#899ba6
 palette = 21=#899ba6
 
 # Foreground & background colors
-background = 3c4c55
-foreground = c5d4dd
-cursor-color = c5d4dd
-selection-background = 6a7d89
-selection-foreground = c5d4dd
+background = #3c4c55
+foreground = #c5d4dd
+cursor-color = #c5d4dd
+selection-background = #6a7d89
+selection-foreground = #c5d4dd
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = c5d4dd
-macos-icon-screen-color = 3c4c55
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #556873
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #83afe5

--- a/themes/ghostty/base16-ocean
+++ b/themes/ghostty/base16-ocean
@@ -29,13 +29,15 @@ palette = 20=#a7adba
 palette = 21=#dfe1e8
 
 # Foreground & background colors
-background = 2b303b
-foreground = c0c5ce
-cursor-color = c0c5ce
-selection-background = 4f5b66
-selection-foreground = c0c5ce
+background = #2b303b
+foreground = #c0c5ce
+cursor-color = #c0c5ce
+selection-background = #4f5b66
+selection-foreground = #c0c5ce
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = c0c5ce
-macos-icon-screen-color = 2b303b
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #eff1f5
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #8fa1b3

--- a/themes/ghostty/base16-oceanicnext
+++ b/themes/ghostty/base16-oceanicnext
@@ -29,13 +29,15 @@ palette = 20=#a7adba
 palette = 21=#cdd3de
 
 # Foreground & background colors
-background = 1b2b34
-foreground = c0c5ce
-cursor-color = c0c5ce
-selection-background = 4f5b66
-selection-foreground = c0c5ce
+background = #1b2b34
+foreground = #c0c5ce
+cursor-color = #c0c5ce
+selection-background = #4f5b66
+selection-foreground = #c0c5ce
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = c0c5ce
-macos-icon-screen-color = 1b2b34
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #d8dee9
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #6699cc

--- a/themes/ghostty/base16-one-light
+++ b/themes/ghostty/base16-one-light
@@ -29,13 +29,15 @@ palette = 20=#696c77
 palette = 21=#202227
 
 # Foreground & background colors
-background = fafafa
-foreground = 383a42
-cursor-color = 383a42
-selection-background = e5e5e6
-selection-foreground = 383a42
+background = #fafafa
+foreground = #383a42
+cursor-color = #383a42
+selection-background = #e5e5e6
+selection-foreground = #383a42
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 383a42
-macos-icon-screen-color = fafafa
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #090a0b
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #4078f2

--- a/themes/ghostty/base16-onedark
+++ b/themes/ghostty/base16-onedark
@@ -29,13 +29,15 @@ palette = 20=#565c64
 palette = 21=#b6bdca
 
 # Foreground & background colors
-background = 282c34
-foreground = abb2bf
-cursor-color = abb2bf
-selection-background = 3e4451
-selection-foreground = abb2bf
+background = #282c34
+foreground = #abb2bf
+cursor-color = #abb2bf
+selection-background = #3e4451
+selection-foreground = #abb2bf
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = abb2bf
-macos-icon-screen-color = 282c34
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #c8ccd4
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #61afef

--- a/themes/ghostty/base16-onedark-dark
+++ b/themes/ghostty/base16-onedark-dark
@@ -29,13 +29,15 @@ palette = 20=#565c64
 palette = 21=#b6bdca
 
 # Foreground & background colors
-background = 000000
-foreground = abb2bf
-cursor-color = abb2bf
-selection-background = 2c313a
-selection-foreground = abb2bf
+background = #000000
+foreground = #abb2bf
+cursor-color = #abb2bf
+selection-background = #2c313a
+selection-foreground = #abb2bf
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = abb2bf
-macos-icon-screen-color = 000000
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #c8ccd4
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #61afef

--- a/themes/ghostty/base16-outrun-dark
+++ b/themes/ghostty/base16-outrun-dark
@@ -29,13 +29,15 @@ palette = 20=#b0b0da
 palette = 21=#e0e0ff
 
 # Foreground & background colors
-background = 00002a
-foreground = d0d0fa
-cursor-color = d0d0fa
-selection-background = 30305a
-selection-foreground = d0d0fa
+background = #00002a
+foreground = #d0d0fa
+cursor-color = #d0d0fa
+selection-background = #30305a
+selection-foreground = #d0d0fa
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = d0d0fa
-macos-icon-screen-color = 00002a
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #f5f5ff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #66b0ff

--- a/themes/ghostty/base16-oxocarbon-dark
+++ b/themes/ghostty/base16-oxocarbon-dark
@@ -29,13 +29,15 @@ palette = 20=#dde1e6
 palette = 21=#ffffff
 
 # Foreground & background colors
-background = 161616
-foreground = f2f4f8
-cursor-color = f2f4f8
-selection-background = 393939
-selection-foreground = f2f4f8
+background = #161616
+foreground = #f2f4f8
+cursor-color = #f2f4f8
+selection-background = #393939
+selection-foreground = #f2f4f8
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = f2f4f8
-macos-icon-screen-color = 161616
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #08bdba
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #42be65

--- a/themes/ghostty/base16-oxocarbon-light
+++ b/themes/ghostty/base16-oxocarbon-light
@@ -29,13 +29,15 @@ palette = 20=#262626
 palette = 21=#525252
 
 # Foreground & background colors
-background = f2f4f8
-foreground = 393939
-cursor-color = 393939
-selection-background = 525252
-selection-foreground = 393939
+background = #f2f4f8
+foreground = #393939
+cursor-color = #393939
+selection-background = #525252
+selection-foreground = #393939
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 393939
-macos-icon-screen-color = f2f4f8
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #08bdba
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #42be65

--- a/themes/ghostty/base16-pandora
+++ b/themes/ghostty/base16-pandora
@@ -29,13 +29,15 @@ palette = 20=#9b2a46
 palette = 21=#81506a
 
 # Foreground & background colors
-background = 131213
-foreground = f15c99
-cursor-color = f15c99
-selection-background = 472234
-selection-foreground = f15c99
+background = #131213
+foreground = #f15c99
+cursor-color = #f15c99
+selection-background = #472234
+selection-foreground = #f15c99
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = f15c99
-macos-icon-screen-color = 131213
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #632227
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #008080

--- a/themes/ghostty/base16-papercolor-dark
+++ b/themes/ghostty/base16-papercolor-dark
@@ -29,13 +29,15 @@ palette = 20=#5fafd7
 palette = 21=#d7875f
 
 # Foreground & background colors
-background = 1c1c1c
-foreground = 808080
-cursor-color = 808080
-selection-background = 5faf00
-selection-foreground = 808080
+background = #1c1c1c
+foreground = #808080
+cursor-color = #808080
+selection-background = #5faf00
+selection-foreground = #808080
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 808080
-macos-icon-screen-color = 1c1c1c
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #d0d0d0
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #ff5faf

--- a/themes/ghostty/base16-papercolor-light
+++ b/themes/ghostty/base16-papercolor-light
@@ -29,13 +29,15 @@ palette = 20=#0087af
 palette = 21=#005f87
 
 # Foreground & background colors
-background = eeeeee
-foreground = 444444
-cursor-color = 444444
-selection-background = 008700
-selection-foreground = 444444
+background = #eeeeee
+foreground = #444444
+cursor-color = #444444
+selection-background = #008700
+selection-foreground = #444444
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 444444
-macos-icon-screen-color = eeeeee
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #878787
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #d75f00

--- a/themes/ghostty/base16-paraiso
+++ b/themes/ghostty/base16-paraiso
@@ -29,13 +29,15 @@ palette = 20=#8d8687
 palette = 21=#b9b6b0
 
 # Foreground & background colors
-background = 2f1e2e
-foreground = a39e9b
-cursor-color = a39e9b
-selection-background = 4f424c
-selection-foreground = a39e9b
+background = #2f1e2e
+foreground = #a39e9b
+cursor-color = #a39e9b
+selection-background = #4f424c
+selection-foreground = #a39e9b
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = a39e9b
-macos-icon-screen-color = 2f1e2e
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #e7e9db
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #06b6ef

--- a/themes/ghostty/base16-pasque
+++ b/themes/ghostty/base16-pasque
@@ -29,13 +29,15 @@ palette = 20=#bebcbf
 palette = 21=#edeaef
 
 # Foreground & background colors
-background = 271c3a
-foreground = dedcdf
-cursor-color = dedcdf
-selection-background = 3e2d5c
-selection-foreground = dedcdf
+background = #271c3a
+foreground = #dedcdf
+cursor-color = #dedcdf
+selection-background = #3e2d5c
+selection-foreground = #dedcdf
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = dedcdf
-macos-icon-screen-color = 271c3a
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #bbaadd
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #8e7dc6

--- a/themes/ghostty/base16-phd
+++ b/themes/ghostty/base16-phd
@@ -29,13 +29,15 @@ palette = 20=#9a99a3
 palette = 21=#dbdde0
 
 # Foreground & background colors
-background = 061229
-foreground = b8bbc2
-cursor-color = b8bbc2
-selection-background = 4d5666
-selection-foreground = b8bbc2
+background = #061229
+foreground = #b8bbc2
+cursor-color = #b8bbc2
+selection-background = #4d5666
+selection-foreground = #b8bbc2
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = b8bbc2
-macos-icon-screen-color = 061229
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #5299bf

--- a/themes/ghostty/base16-pico
+++ b/themes/ghostty/base16-pico
@@ -29,13 +29,15 @@ palette = 20=#ab5236
 palette = 21=#c2c3c7
 
 # Foreground & background colors
-background = 000000
-foreground = 5f574f
-cursor-color = 5f574f
-selection-background = 7e2553
-selection-foreground = 5f574f
+background = #000000
+foreground = #5f574f
+cursor-color = #5f574f
+selection-background = #7e2553
+selection-foreground = #5f574f
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 5f574f
-macos-icon-screen-color = 000000
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #fff1e8
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #83769c

--- a/themes/ghostty/base16-pinky
+++ b/themes/ghostty/base16-pinky
@@ -29,13 +29,15 @@ palette = 20=#e7dbdb
 palette = 21=#ffffff
 
 # Foreground & background colors
-background = 171517
-foreground = f5f5f5
-cursor-color = f5f5f5
-selection-background = 1d1b1d
-selection-foreground = f5f5f5
+background = #171517
+foreground = #f5f5f5
+cursor-color = #f5f5f5
+selection-background = #1d1b1d
+selection-foreground = #f5f5f5
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = f5f5f5
-macos-icon-screen-color = 171517
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #f7f3f7
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #00ffff

--- a/themes/ghostty/base16-pop
+++ b/themes/ghostty/base16-pop
@@ -29,13 +29,15 @@ palette = 20=#b0b0b0
 palette = 21=#e0e0e0
 
 # Foreground & background colors
-background = 000000
-foreground = d0d0d0
-cursor-color = d0d0d0
-selection-background = 303030
-selection-foreground = d0d0d0
+background = #000000
+foreground = #d0d0d0
+cursor-color = #d0d0d0
+selection-background = #303030
+selection-foreground = #d0d0d0
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = d0d0d0
-macos-icon-screen-color = 000000
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #0e5a94

--- a/themes/ghostty/base16-porple
+++ b/themes/ghostty/base16-porple
@@ -29,13 +29,15 @@ palette = 20=#b8b8b8
 palette = 21=#e8e8e8
 
 # Foreground & background colors
-background = 292c36
-foreground = d8d8d8
-cursor-color = d8d8d8
-selection-background = 474160
-selection-foreground = d8d8d8
+background = #292c36
+foreground = #d8d8d8
+cursor-color = #d8d8d8
+selection-background = #474160
+selection-foreground = #d8d8d8
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = d8d8d8
-macos-icon-screen-color = 292c36
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #f8f8f8
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #8485ce

--- a/themes/ghostty/base16-precious-dark-eleven
+++ b/themes/ghostty/base16-precious-dark-eleven
@@ -29,13 +29,15 @@ palette = 20=#a8a8a7
 palette = 21=#b8b7b6
 
 # Foreground & background colors
-background = 1c1e20
-foreground = b8b7b6
-cursor-color = b8b7b6
-selection-background = 37393a
-selection-foreground = b8b7b6
+background = #1c1e20
+foreground = #b8b7b6
+cursor-color = #b8b7b6
+selection-background = #37393a
+selection-foreground = #b8b7b6
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = b8b7b6
-macos-icon-screen-color = 1c1e20
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #b8b7b6
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #68b0ee

--- a/themes/ghostty/base16-precious-dark-fifteen
+++ b/themes/ghostty/base16-precious-dark-fifteen
@@ -29,13 +29,15 @@ palette = 20=#abaaa8
 palette = 21=#bab9b6
 
 # Foreground & background colors
-background = 23262b
-foreground = bab9b6
-cursor-color = bab9b6
-selection-background = 3e4044
-selection-foreground = bab9b6
+background = #23262b
+foreground = #bab9b6
+cursor-color = #bab9b6
+selection-background = #3e4044
+selection-foreground = #bab9b6
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = bab9b6
-macos-icon-screen-color = 23262b
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #bab9b6
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #66b0ef

--- a/themes/ghostty/base16-precious-light-warm
+++ b/themes/ghostty/base16-precious-light-warm
@@ -29,13 +29,15 @@ palette = 20=#5d6065
 palette = 21=#4e5359
 
 # Foreground & background colors
-background = fff5e5
-foreground = 4e5359
-cursor-color = 4e5359
-selection-background = d9d3c8
-selection-foreground = 4e5359
+background = #fff5e5
+foreground = #4e5359
+cursor-color = #4e5359
+selection-background = #d9d3c8
+selection-foreground = #4e5359
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 4e5359
-macos-icon-screen-color = fff5e5
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #4e5359
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #246da5

--- a/themes/ghostty/base16-precious-light-white
+++ b/themes/ghostty/base16-precious-light-white
@@ -29,13 +29,15 @@ palette = 20=#636363
 palette = 21=#555555
 
 # Foreground & background colors
-background = ffffff
-foreground = 555555
-cursor-color = 555555
-selection-background = dbdbdb
-selection-foreground = 555555
+background = #ffffff
+foreground = #555555
+cursor-color = #555555
+selection-background = #dbdbdb
+selection-foreground = #555555
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 555555
-macos-icon-screen-color = ffffff
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #555555
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #186daa

--- a/themes/ghostty/base16-primer-dark
+++ b/themes/ghostty/base16-primer-dark
@@ -29,13 +29,15 @@ palette = 20=#8b949e
 palette = 21=#c9d1d9
 
 # Foreground & background colors
-background = 010409
-foreground = b1bac4
-cursor-color = b1bac4
-selection-background = 30363d
-selection-foreground = b1bac4
+background = #010409
+foreground = #b1bac4
+cursor-color = #b1bac4
+selection-background = #30363d
+selection-foreground = #b1bac4
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = b1bac4
-macos-icon-screen-color = 010409
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #f0f6fc
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #58a6ff

--- a/themes/ghostty/base16-primer-dark-dimmed
+++ b/themes/ghostty/base16-primer-dark-dimmed
@@ -29,13 +29,15 @@ palette = 20=#768390
 palette = 21=#adbac7
 
 # Foreground & background colors
-background = 1c2128
-foreground = 909dab
-cursor-color = 909dab
-selection-background = 444c56
-selection-foreground = 909dab
+background = #1c2128
+foreground = #909dab
+cursor-color = #909dab
+selection-background = #444c56
+selection-foreground = #909dab
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 909dab
-macos-icon-screen-color = 1c2128
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #cdd9e5
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #539bf5

--- a/themes/ghostty/base16-primer-light
+++ b/themes/ghostty/base16-primer-light
@@ -29,13 +29,15 @@ palette = 20=#444d56
 palette = 21=#24292e
 
 # Foreground & background colors
-background = fafbfc
-foreground = 2f363d
-cursor-color = 2f363d
-selection-background = d1d5da
-selection-foreground = 2f363d
+background = #fafbfc
+foreground = #2f363d
+cursor-color = #2f363d
+selection-background = #d1d5da
+selection-foreground = #2f363d
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 2f363d
-macos-icon-screen-color = fafbfc
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #1b1f23
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #0366d6

--- a/themes/ghostty/base16-purpledream
+++ b/themes/ghostty/base16-purpledream
@@ -29,13 +29,15 @@ palette = 20=#bbb0bb
 palette = 21=#eee0ee
 
 # Foreground & background colors
-background = 100510
-foreground = ddd0dd
-cursor-color = ddd0dd
-selection-background = 403040
-selection-foreground = ddd0dd
+background = #100510
+foreground = #ddd0dd
+cursor-color = #ddd0dd
+selection-background = #403040
+selection-foreground = #ddd0dd
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = ddd0dd
-macos-icon-screen-color = 100510
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #fff0ff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #00a0f0

--- a/themes/ghostty/base16-qualia
+++ b/themes/ghostty/base16-qualia
@@ -29,13 +29,15 @@ palette = 20=#808080
 palette = 21=#c0c0c0
 
 # Foreground & background colors
-background = 101010
-foreground = c0c0c0
-cursor-color = c0c0c0
-selection-background = 454545
-selection-foreground = c0c0c0
+background = #101010
+foreground = #c0c0c0
+cursor-color = #c0c0c0
+selection-background = #454545
+selection-foreground = #c0c0c0
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = c0c0c0
-macos-icon-screen-color = 101010
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #454545
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #50cacd

--- a/themes/ghostty/base16-railscasts
+++ b/themes/ghostty/base16-railscasts
@@ -29,13 +29,15 @@ palette = 20=#d4cfc9
 palette = 21=#f4f1ed
 
 # Foreground & background colors
-background = 2b2b2b
-foreground = e6e1dc
-cursor-color = e6e1dc
-selection-background = 3a4055
-selection-foreground = e6e1dc
+background = #2b2b2b
+foreground = #e6e1dc
+cursor-color = #e6e1dc
+selection-background = #3a4055
+selection-foreground = #e6e1dc
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = e6e1dc
-macos-icon-screen-color = 2b2b2b
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #f9f7f3
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #6d9cbe

--- a/themes/ghostty/base16-rebecca
+++ b/themes/ghostty/base16-rebecca
@@ -29,13 +29,15 @@ palette = 20=#a0a0c5
 palette = 21=#ccccff
 
 # Foreground & background colors
-background = 292a44
-foreground = f1eff8
-cursor-color = f1eff8
-selection-background = 383a62
-selection-foreground = f1eff8
+background = #292a44
+foreground = #f1eff8
+cursor-color = #f1eff8
+selection-background = #383a62
+selection-foreground = #f1eff8
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = f1eff8
-macos-icon-screen-color = 292a44
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #53495d
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #2de0a7

--- a/themes/ghostty/base16-rose-pine
+++ b/themes/ghostty/base16-rose-pine
@@ -29,13 +29,15 @@ palette = 20=#908caa
 palette = 21=#e0def4
 
 # Foreground & background colors
-background = 191724
-foreground = e0def4
-cursor-color = e0def4
-selection-background = 26233a
-selection-foreground = e0def4
+background = #191724
+foreground = #e0def4
+cursor-color = #e0def4
+selection-background = #26233a
+selection-foreground = #e0def4
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = e0def4
-macos-icon-screen-color = 191724
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #524f67
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #c4a7e7

--- a/themes/ghostty/base16-rose-pine-dawn
+++ b/themes/ghostty/base16-rose-pine-dawn
@@ -29,13 +29,15 @@ palette = 20=#797593
 palette = 21=#575279
 
 # Foreground & background colors
-background = faf4ed
-foreground = 575279
-cursor-color = 575279
-selection-background = f2e9de
-selection-foreground = 575279
+background = #faf4ed
+foreground = #575279
+cursor-color = #575279
+selection-background = #f2e9de
+selection-foreground = #575279
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 575279
-macos-icon-screen-color = faf4ed
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #cecacd
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #907aa9

--- a/themes/ghostty/base16-rose-pine-moon
+++ b/themes/ghostty/base16-rose-pine-moon
@@ -29,13 +29,15 @@ palette = 20=#908caa
 palette = 21=#e0def4
 
 # Foreground & background colors
-background = 232136
-foreground = e0def4
-cursor-color = e0def4
-selection-background = 393552
-selection-foreground = e0def4
+background = #232136
+foreground = #e0def4
+cursor-color = #e0def4
+selection-background = #393552
+selection-foreground = #e0def4
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = e0def4
-macos-icon-screen-color = 232136
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #56526e
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #c4a7e7

--- a/themes/ghostty/base16-saga
+++ b/themes/ghostty/base16-saga
@@ -29,13 +29,15 @@ palette = 20=#192630
 palette = 21=#f8eae7
 
 # Foreground & background colors
-background = 05080a
-foreground = dce2f7
-cursor-color = dce2f7
-selection-background = 0f181e
-selection-foreground = dce2f7
+background = #05080a
+foreground = #dce2f7
+cursor-color = #dce2f7
+selection-background = #0f181e
+selection-foreground = #dce2f7
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = dce2f7
-macos-icon-screen-color = 05080a
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ccd3fe
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #c9fff7

--- a/themes/ghostty/base16-sagelight
+++ b/themes/ghostty/base16-sagelight
@@ -29,13 +29,15 @@ palette = 20=#585858
 palette = 21=#282828
 
 # Foreground & background colors
-background = f8f8f8
-foreground = 383838
-cursor-color = 383838
-selection-background = d8d8d8
-selection-foreground = 383838
+background = #f8f8f8
+foreground = #383838
+cursor-color = #383838
+selection-background = #d8d8d8
+selection-foreground = #383838
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 383838
-macos-icon-screen-color = f8f8f8
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #181818
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #a0a7d2

--- a/themes/ghostty/base16-sakura
+++ b/themes/ghostty/base16-sakura
@@ -29,13 +29,15 @@ palette = 20=#665055
 palette = 21=#42383a
 
 # Foreground & background colors
-background = feedf3
-foreground = 564448
-cursor-color = 564448
-selection-background = e0ccd1
-selection-foreground = 564448
+background = #feedf3
+foreground = #564448
+cursor-color = #564448
+selection-background = #e0ccd1
+selection-foreground = #564448
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 564448
-macos-icon-screen-color = feedf3
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #33292b
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #006e93

--- a/themes/ghostty/base16-sandcastle
+++ b/themes/ghostty/base16-sandcastle
@@ -29,13 +29,15 @@ palette = 20=#928374
 palette = 21=#d5c4a1
 
 # Foreground & background colors
-background = 282c34
-foreground = a89984
-cursor-color = a89984
-selection-background = 3e4451
-selection-foreground = a89984
+background = #282c34
+foreground = #a89984
+cursor-color = #a89984
+selection-background = #3e4451
+selection-foreground = #a89984
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = a89984
-macos-icon-screen-color = 282c34
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #fdf4c1
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #83a598

--- a/themes/ghostty/base16-selenized-black
+++ b/themes/ghostty/base16-selenized-black
@@ -29,13 +29,15 @@ palette = 20=#777777
 palette = 21=#dedede
 
 # Foreground & background colors
-background = 181818
-foreground = b9b9b9
-cursor-color = b9b9b9
-selection-background = 3b3b3b
-selection-foreground = b9b9b9
+background = #181818
+foreground = #b9b9b9
+cursor-color = #b9b9b9
+selection-background = #3b3b3b
+selection-foreground = #b9b9b9
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = b9b9b9
-macos-icon-screen-color = 181818
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #dedede
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #368aeb

--- a/themes/ghostty/base16-selenized-dark
+++ b/themes/ghostty/base16-selenized-dark
@@ -29,13 +29,15 @@ palette = 20=#72898f
 palette = 21=#cad8d9
 
 # Foreground & background colors
-background = 103c48
-foreground = adbcbc
-cursor-color = adbcbc
-selection-background = 2d5b69
-selection-foreground = adbcbc
+background = #103c48
+foreground = #adbcbc
+cursor-color = #adbcbc
+selection-background = #2d5b69
+selection-foreground = #adbcbc
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = adbcbc
-macos-icon-screen-color = 103c48
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #cad8d9
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #4695f7

--- a/themes/ghostty/base16-selenized-light
+++ b/themes/ghostty/base16-selenized-light
@@ -29,13 +29,15 @@ palette = 20=#909995
 palette = 21=#3a4d53
 
 # Foreground & background colors
-background = fbf3db
-foreground = 53676d
-cursor-color = 53676d
-selection-background = d5cdb6
-selection-foreground = 53676d
+background = #fbf3db
+foreground = #53676d
+cursor-color = #53676d
+selection-background = #d5cdb6
+selection-foreground = #53676d
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 53676d
-macos-icon-screen-color = fbf3db
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #3a4d53
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #006dce

--- a/themes/ghostty/base16-selenized-white
+++ b/themes/ghostty/base16-selenized-white
@@ -29,13 +29,15 @@ palette = 20=#878787
 palette = 21=#282828
 
 # Foreground & background colors
-background = ffffff
-foreground = 474747
-cursor-color = 474747
-selection-background = cdcdcd
-selection-foreground = 474747
+background = #ffffff
+foreground = #474747
+cursor-color = #474747
+selection-background = #cdcdcd
+selection-foreground = #474747
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 474747
-macos-icon-screen-color = ffffff
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #282828
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #0054cf

--- a/themes/ghostty/base16-seti
+++ b/themes/ghostty/base16-seti
@@ -29,13 +29,15 @@ palette = 20=#43a5d5
 palette = 21=#eeeeee
 
 # Foreground & background colors
-background = 151718
-foreground = d6d6d6
-cursor-color = d6d6d6
-selection-background = 3b758c
-selection-foreground = d6d6d6
+background = #151718
+foreground = #d6d6d6
+cursor-color = #d6d6d6
+selection-background = #3b758c
+selection-foreground = #d6d6d6
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = d6d6d6
-macos-icon-screen-color = 151718
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #55b5db

--- a/themes/ghostty/base16-shades-of-purple
+++ b/themes/ghostty/base16-shades-of-purple
@@ -29,13 +29,15 @@ palette = 20=#6871ff
 palette = 21=#ff77ff
 
 # Foreground & background colors
-background = 1e1e3f
-foreground = c7c7c7
-cursor-color = c7c7c7
-selection-background = f1d000
-selection-foreground = c7c7c7
+background = #1e1e3f
+foreground = #c7c7c7
+cursor-color = #c7c7c7
+selection-background = #f1d000
+selection-foreground = #c7c7c7
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = c7c7c7
-macos-icon-screen-color = 1e1e3f
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #6943ff

--- a/themes/ghostty/base16-shadesmear-dark
+++ b/themes/ghostty/base16-shadesmear-dark
@@ -29,13 +29,15 @@ palette = 20=#e4e4e4
 palette = 21=#e4e4e4
 
 # Foreground & background colors
-background = 232323
-foreground = dbdbdb
-cursor-color = dbdbdb
-selection-background = 4e4e4e
-selection-foreground = dbdbdb
+background = #232323
+foreground = #dbdbdb
+cursor-color = #dbdbdb
+selection-background = #4e4e4e
+selection-foreground = #dbdbdb
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = dbdbdb
-macos-icon-screen-color = 232323
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #1c1c1c
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #376388

--- a/themes/ghostty/base16-shadesmear-light
+++ b/themes/ghostty/base16-shadesmear-light
@@ -29,13 +29,15 @@ palette = 20=#1c1c1c
 palette = 21=#1c1c1c
 
 # Foreground & background colors
-background = dbdbdb
-foreground = 232323
-cursor-color = 232323
-selection-background = c0c0c0
-selection-foreground = 232323
+background = #dbdbdb
+foreground = #232323
+cursor-color = #232323
+selection-background = #c0c0c0
+selection-foreground = #232323
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 232323
-macos-icon-screen-color = dbdbdb
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #e4e4e4
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #376388

--- a/themes/ghostty/base16-shapeshifter
+++ b/themes/ghostty/base16-shapeshifter
@@ -29,13 +29,15 @@ palette = 20=#343434
 palette = 21=#040404
 
 # Foreground & background colors
-background = f9f9f9
-foreground = 102015
-cursor-color = 102015
-selection-background = ababab
-selection-foreground = 102015
+background = #f9f9f9
+foreground = #102015
+cursor-color = #102015
+selection-background = #ababab
+selection-foreground = #102015
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 102015
-macos-icon-screen-color = f9f9f9
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #000000
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #3b48e3

--- a/themes/ghostty/base16-silk-dark
+++ b/themes/ghostty/base16-silk-dark
@@ -29,13 +29,15 @@ palette = 20=#9dc8cd
 palette = 21=#cbf2f7
 
 # Foreground & background colors
-background = 0e3c46
-foreground = c7dbdd
-cursor-color = c7dbdd
-selection-background = 2a5054
-selection-foreground = c7dbdd
+background = #0e3c46
+foreground = #c7dbdd
+cursor-color = #c7dbdd
+selection-background = #2a5054
+selection-foreground = #c7dbdd
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = c7dbdd
-macos-icon-screen-color = 0e3c46
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #d2faff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #46bddd

--- a/themes/ghostty/base16-silk-light
+++ b/themes/ghostty/base16-silk-light
@@ -29,13 +29,15 @@ palette = 20=#4b5b5f
 palette = 21=#0e3c46
 
 # Foreground & background colors
-background = e9f1ef
-foreground = 385156
-cursor-color = 385156
-selection-background = 90b7b6
-selection-foreground = 385156
+background = #e9f1ef
+foreground = #385156
+cursor-color = #385156
+selection-background = #90b7b6
+selection-foreground = #385156
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 385156
-macos-icon-screen-color = e9f1ef
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #d2faff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #39aac9

--- a/themes/ghostty/base16-snazzy
+++ b/themes/ghostty/base16-snazzy
@@ -29,13 +29,15 @@ palette = 20=#a5a5a9
 palette = 21=#eff0eb
 
 # Foreground & background colors
-background = 282a36
-foreground = e2e4e5
-cursor-color = e2e4e5
-selection-background = 43454f
-selection-foreground = e2e4e5
+background = #282a36
+foreground = #e2e4e5
+cursor-color = #e2e4e5
+selection-background = #43454f
+selection-foreground = #e2e4e5
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = e2e4e5
-macos-icon-screen-color = 282a36
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #f1f1f0
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #57c7ff

--- a/themes/ghostty/base16-solarflare
+++ b/themes/ghostty/base16-solarflare
@@ -29,13 +29,15 @@ palette = 20=#85939e
 palette = 21=#e8e9ed
 
 # Foreground & background colors
-background = 18262f
-foreground = a6afb8
-cursor-color = a6afb8
-selection-background = 586875
-selection-foreground = a6afb8
+background = #18262f
+foreground = #a6afb8
+cursor-color = #a6afb8
+selection-background = #586875
+selection-foreground = #a6afb8
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = a6afb8
-macos-icon-screen-color = 18262f
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #f5f7fa
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #33b5e1

--- a/themes/ghostty/base16-solarflare-light
+++ b/themes/ghostty/base16-solarflare-light
@@ -29,13 +29,15 @@ palette = 20=#667581
 palette = 21=#222e38
 
 # Foreground & background colors
-background = f5f7fa
-foreground = 586875
-cursor-color = 586875
-selection-background = a6afb8
-selection-foreground = 586875
+background = #f5f7fa
+foreground = #586875
+cursor-color = #586875
+selection-background = #a6afb8
+selection-foreground = #586875
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 586875
-macos-icon-screen-color = f5f7fa
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #18262f
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #33b5e1

--- a/themes/ghostty/base16-solarized-dark
+++ b/themes/ghostty/base16-solarized-dark
@@ -29,13 +29,15 @@ palette = 20=#839496
 palette = 21=#eee8d5
 
 # Foreground & background colors
-background = 002b36
-foreground = 93a1a1
-cursor-color = 93a1a1
-selection-background = 586e75
-selection-foreground = 93a1a1
+background = #002b36
+foreground = #93a1a1
+cursor-color = #93a1a1
+selection-background = #586e75
+selection-foreground = #93a1a1
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 93a1a1
-macos-icon-screen-color = 002b36
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #fdf6e3
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #268bd2

--- a/themes/ghostty/base16-solarized-light
+++ b/themes/ghostty/base16-solarized-light
@@ -29,13 +29,15 @@ palette = 20=#657b83
 palette = 21=#073642
 
 # Foreground & background colors
-background = fdf6e3
-foreground = 586e75
-cursor-color = 586e75
-selection-background = 93a1a1
-selection-foreground = 586e75
+background = #fdf6e3
+foreground = #586e75
+cursor-color = #586e75
+selection-background = #93a1a1
+selection-foreground = #586e75
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 586e75
-macos-icon-screen-color = fdf6e3
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #002b36
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #268bd2

--- a/themes/ghostty/base16-spaceduck
+++ b/themes/ghostty/base16-spaceduck
@@ -29,13 +29,15 @@ palette = 20=#818596
 palette = 21=#c1c3cc
 
 # Foreground & background colors
-background = 16172d
-foreground = ecf0c1
-cursor-color = ecf0c1
-selection-background = 30365f
-selection-foreground = ecf0c1
+background = #16172d
+foreground = #ecf0c1
+cursor-color = #ecf0c1
+selection-background = #30365f
+selection-foreground = #ecf0c1
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = ecf0c1
-macos-icon-screen-color = 16172d
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #7a5ccc

--- a/themes/ghostty/base16-spacemacs
+++ b/themes/ghostty/base16-spacemacs
@@ -29,13 +29,15 @@ palette = 20=#b8b8b8
 palette = 21=#e8e8e8
 
 # Foreground & background colors
-background = 1f2022
-foreground = a3a3a3
-cursor-color = a3a3a3
-selection-background = 444155
-selection-foreground = a3a3a3
+background = #1f2022
+foreground = #a3a3a3
+cursor-color = #a3a3a3
+selection-background = #444155
+selection-foreground = #a3a3a3
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = a3a3a3
-macos-icon-screen-color = 1f2022
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #f8f8f8
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #4f97d7

--- a/themes/ghostty/base16-sparky
+++ b/themes/ghostty/base16-sparky
@@ -29,13 +29,15 @@ palette = 20=#00778b
 palette = 21=#f5f5f1
 
 # Foreground & background colors
-background = 072b31
-foreground = f4f5f0
-cursor-color = f4f5f0
-selection-background = 003c46
-selection-foreground = f4f5f0
+background = #072b31
+foreground = #f4f5f0
+cursor-color = #f4f5f0
+selection-background = #003c46
+selection-foreground = #f4f5f0
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = f4f5f0
-macos-icon-screen-color = 072b31
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #4698cb

--- a/themes/ghostty/base16-standardized-dark
+++ b/themes/ghostty/base16-standardized-dark
@@ -29,13 +29,15 @@ palette = 20=#898989
 palette = 21=#e0e0e0
 
 # Foreground & background colors
-background = 222222
-foreground = c0c0c0
-cursor-color = c0c0c0
-selection-background = 555555
-selection-foreground = c0c0c0
+background = #222222
+foreground = #c0c0c0
+cursor-color = #c0c0c0
+selection-background = #555555
+selection-foreground = #c0c0c0
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = c0c0c0
-macos-icon-screen-color = 222222
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #00a3f2

--- a/themes/ghostty/base16-standardized-light
+++ b/themes/ghostty/base16-standardized-light
@@ -29,13 +29,15 @@ palette = 20=#767676
 palette = 21=#333333
 
 # Foreground & background colors
-background = ffffff
-foreground = 444444
-cursor-color = 444444
-selection-background = cccccc
-selection-foreground = 444444
+background = #ffffff
+foreground = #444444
+cursor-color = #444444
+selection-background = #cccccc
+selection-foreground = #444444
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 444444
-macos-icon-screen-color = ffffff
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #222222
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #3173c5

--- a/themes/ghostty/base16-stella
+++ b/themes/ghostty/base16-stella
@@ -29,13 +29,15 @@ palette = 20=#7f7192
 palette = 21=#b4a5c8
 
 # Foreground & background colors
-background = 2b213c
-foreground = 998bad
-cursor-color = 998bad
-selection-background = 4d4160
-selection-foreground = 998bad
+background = #2b213c
+foreground = #998bad
+cursor-color = #998bad
+selection-background = #4d4160
+selection-foreground = #998bad
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 998bad
-macos-icon-screen-color = 2b213c
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ebdcff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #a5aad4

--- a/themes/ghostty/base16-still-alive
+++ b/themes/ghostty/base16-still-alive
@@ -29,13 +29,15 @@ palette = 20=#f00000
 palette = 21=#489000
 
 # Foreground & background colors
-background = f0f0f0
-foreground = d80000
-cursor-color = d80000
-selection-background = fff018
-selection-foreground = d80000
+background = #f0f0f0
+foreground = #d80000
+cursor-color = #d80000
+selection-background = #fff018
+selection-foreground = #d80000
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = d80000
-macos-icon-screen-color = f0f0f0
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #30a860
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #001878

--- a/themes/ghostty/base16-summercamp
+++ b/themes/ghostty/base16-summercamp
@@ -29,13 +29,15 @@ palette = 20=#5f5b45
 palette = 21=#bab696
 
 # Foreground & background colors
-background = 1c1810
-foreground = 736e55
-cursor-color = 736e55
-selection-background = 3a3527
-selection-foreground = 736e55
+background = #1c1810
+foreground = #736e55
+cursor-color = #736e55
+selection-background = #3a3527
+selection-foreground = #736e55
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 736e55
-macos-icon-screen-color = 1c1810
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #f8f5de
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #489bf0

--- a/themes/ghostty/base16-summerfruit-dark
+++ b/themes/ghostty/base16-summerfruit-dark
@@ -29,13 +29,15 @@ palette = 20=#b0b0b0
 palette = 21=#e0e0e0
 
 # Foreground & background colors
-background = 151515
-foreground = d0d0d0
-cursor-color = d0d0d0
-selection-background = 303030
-selection-foreground = d0d0d0
+background = #151515
+foreground = #d0d0d0
+cursor-color = #d0d0d0
+selection-background = #303030
+selection-foreground = #d0d0d0
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = d0d0d0
-macos-icon-screen-color = 151515
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #3777e6

--- a/themes/ghostty/base16-summerfruit-light
+++ b/themes/ghostty/base16-summerfruit-light
@@ -29,13 +29,15 @@ palette = 20=#000000
 palette = 21=#151515
 
 # Foreground & background colors
-background = ffffff
-foreground = 101010
-cursor-color = 101010
-selection-background = d0d0d0
-selection-foreground = 101010
+background = #ffffff
+foreground = #101010
+cursor-color = #101010
+selection-background = #d0d0d0
+selection-foreground = #101010
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 101010
-macos-icon-screen-color = ffffff
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #202020
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #3777e6

--- a/themes/ghostty/base16-synth-midnight-dark
+++ b/themes/ghostty/base16-synth-midnight-dark
@@ -29,13 +29,15 @@ palette = 20=#a3a5a6
 palette = 21=#cfd1d2
 
 # Foreground & background colors
-background = 050608
-foreground = c1c3c4
-cursor-color = c1c3c4
-selection-background = 28292a
-selection-foreground = c1c3c4
+background = #050608
+foreground = #c1c3c4
+cursor-color = #c1c3c4
+selection-background = #28292a
+selection-foreground = #c1c3c4
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = c1c3c4
-macos-icon-screen-color = 050608
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #dddfe0
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #03aeff

--- a/themes/ghostty/base16-synth-midnight-light
+++ b/themes/ghostty/base16-synth-midnight-light
@@ -29,13 +29,15 @@ palette = 20=#474849
 palette = 21=#1a1b1c
 
 # Foreground & background colors
-background = dddfe0
-foreground = 28292a
-cursor-color = 28292a
-selection-background = c1c3c4
-selection-foreground = 28292a
+background = #dddfe0
+foreground = #28292a
+cursor-color = #28292a
+selection-background = #c1c3c4
+selection-foreground = #28292a
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 28292a
-macos-icon-screen-color = dddfe0
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #050608
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #03aeff

--- a/themes/ghostty/base16-tango
+++ b/themes/ghostty/base16-tango
@@ -29,13 +29,15 @@ palette = 20=#729fcf
 palette = 21=#ad7fa8
 
 # Foreground & background colors
-background = 2e3436
-foreground = d3d7cf
-cursor-color = d3d7cf
-selection-background = fce94f
-selection-foreground = d3d7cf
+background = #2e3436
+foreground = #d3d7cf
+cursor-color = #d3d7cf
+selection-background = #fce94f
+selection-foreground = #d3d7cf
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = d3d7cf
-macos-icon-screen-color = 2e3436
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #eeeeec
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #3465a4

--- a/themes/ghostty/base16-tarot
+++ b/themes/ghostty/base16-tarot
@@ -29,13 +29,15 @@ palette = 20=#8c406f
 palette = 21=#c4686d
 
 # Foreground & background colors
-background = 0e091d
-foreground = aa556f
-cursor-color = aa556f
-selection-background = 4b2054
-selection-foreground = aa556f
+background = #0e091d
+foreground = #aa556f
+cursor-color = #aa556f
+selection-background = #4b2054
+selection-foreground = #aa556f
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = aa556f
-macos-icon-screen-color = 0e091d
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #dc8f7c
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #6e6080

--- a/themes/ghostty/base16-tender
+++ b/themes/ghostty/base16-tender
@@ -29,13 +29,15 @@ palette = 20=#b8b8b8
 palette = 21=#e8e8e8
 
 # Foreground & background colors
-background = 282828
-foreground = eeeeee
-cursor-color = eeeeee
-selection-background = 484848
-selection-foreground = eeeeee
+background = #282828
+foreground = #eeeeee
+cursor-color = #eeeeee
+selection-background = #484848
+selection-foreground = #eeeeee
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = eeeeee
-macos-icon-screen-color = 282828
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #feffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #b3deef

--- a/themes/ghostty/base16-terracotta
+++ b/themes/ghostty/base16-terracotta
@@ -29,13 +29,15 @@ palette = 20=#59453d
 palette = 21=#352a25
 
 # Foreground & background colors
-background = efeae8
-foreground = 473731
-cursor-color = 473731
-selection-background = d0c1bb
-selection-foreground = 473731
+background = #efeae8
+foreground = #473731
+cursor-color = #473731
+selection-background = #d0c1bb
+selection-foreground = #473731
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 473731
-macos-icon-screen-color = efeae8
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #241c19
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #625574

--- a/themes/ghostty/base16-terracotta-dark
+++ b/themes/ghostty/base16-terracotta-dark
@@ -29,13 +29,15 @@ palette = 20=#a78e84
 palette = 21=#cabbb5
 
 # Foreground & background colors
-background = 241d1a
-foreground = b8a59d
-cursor-color = b8a59d
-selection-background = 473933
-selection-foreground = b8a59d
+background = #241d1a
+foreground = #b8a59d
+cursor-color = #b8a59d
+selection-background = #473933
+selection-foreground = #b8a59d
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = b8a59d
-macos-icon-screen-color = 241d1a
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #dcd2ce
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #b0a4c3

--- a/themes/ghostty/base16-tokyo-city-dark
+++ b/themes/ghostty/base16-tokyo-city-dark
@@ -29,13 +29,15 @@ palette = 20=#b7c5d3
 palette = 21=#f6f6f8
 
 # Foreground & background colors
-background = 171d23
-foreground = d8e2ec
-cursor-color = d8e2ec
-selection-background = 28323a
-selection-foreground = d8e2ec
+background = #171d23
+foreground = #d8e2ec
+cursor-color = #d8e2ec
+selection-background = #28323a
+selection-foreground = #d8e2ec
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = d8e2ec
-macos-icon-screen-color = 171d23
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #fbfbfd
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #7aa2f7

--- a/themes/ghostty/base16-tokyo-city-light
+++ b/themes/ghostty/base16-tokyo-city-light
@@ -29,13 +29,15 @@ palette = 20=#4c505e
 palette = 21=#1d252c
 
 # Foreground & background colors
-background = fbfbfd
-foreground = 343b59
-cursor-color = 343b59
-selection-background = edeff6
-selection-foreground = 343b59
+background = #fbfbfd
+foreground = #343b59
+cursor-color = #343b59
+selection-background = #edeff6
+selection-foreground = #343b59
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 343b59
-macos-icon-screen-color = fbfbfd
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #171d23
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #34548a

--- a/themes/ghostty/base16-tokyo-city-terminal-dark
+++ b/themes/ghostty/base16-tokyo-city-terminal-dark
@@ -29,13 +29,15 @@ palette = 20=#b7c5d3
 palette = 21=#f6f6f8
 
 # Foreground & background colors
-background = 171d23
-foreground = d8e2ec
-cursor-color = d8e2ec
-selection-background = 28323a
-selection-foreground = d8e2ec
+background = #171d23
+foreground = #d8e2ec
+cursor-color = #d8e2ec
+selection-background = #28323a
+selection-foreground = #d8e2ec
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = d8e2ec
-macos-icon-screen-color = 171d23
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #fbfbfd
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #539afc

--- a/themes/ghostty/base16-tokyo-city-terminal-light
+++ b/themes/ghostty/base16-tokyo-city-terminal-light
@@ -29,13 +29,15 @@ palette = 20=#526270
 palette = 21=#1d252c
 
 # Foreground & background colors
-background = fbfbfd
-foreground = 28323a
-cursor-color = 28323a
-selection-background = d8e2ec
-selection-foreground = 28323a
+background = #fbfbfd
+foreground = #28323a
+cursor-color = #28323a
+selection-background = #d8e2ec
+selection-foreground = #28323a
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 28323a
-macos-icon-screen-color = fbfbfd
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #171d23
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #34548a

--- a/themes/ghostty/base16-tokyo-night-dark
+++ b/themes/ghostty/base16-tokyo-night-dark
@@ -29,13 +29,15 @@ palette = 20=#787c99
 palette = 21=#cbccd1
 
 # Foreground & background colors
-background = 1a1b26
-foreground = a9b1d6
-cursor-color = a9b1d6
-selection-background = 2f3549
-selection-foreground = a9b1d6
+background = #1a1b26
+foreground = #a9b1d6
+cursor-color = #a9b1d6
+selection-background = #2f3549
+selection-foreground = #a9b1d6
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = a9b1d6
-macos-icon-screen-color = 1a1b26
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #d5d6db
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #2ac3de

--- a/themes/ghostty/base16-tokyo-night-light
+++ b/themes/ghostty/base16-tokyo-night-light
@@ -29,13 +29,15 @@ palette = 20=#4c505e
 palette = 21=#1a1b26
 
 # Foreground & background colors
-background = d5d6db
-foreground = 343b59
-cursor-color = 343b59
-selection-background = dfe0e5
-selection-foreground = 343b59
+background = #d5d6db
+foreground = #343b59
+cursor-color = #343b59
+selection-background = #dfe0e5
+selection-foreground = #343b59
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 343b59
-macos-icon-screen-color = d5d6db
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #1a1b26
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #34548a

--- a/themes/ghostty/base16-tokyo-night-moon
+++ b/themes/ghostty/base16-tokyo-night-moon
@@ -29,13 +29,15 @@ palette = 20=#828bb8
 palette = 21=#828bb8
 
 # Foreground & background colors
-background = 222436
-foreground = 3b4261
-cursor-color = 3b4261
-selection-background = 2d3f76
-selection-foreground = 3b4261
+background = #222436
+foreground = #3b4261
+cursor-color = #3b4261
+selection-background = #2d3f76
+selection-foreground = #3b4261
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 3b4261
-macos-icon-screen-color = 222436
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #c8d3f5
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #82aaff

--- a/themes/ghostty/base16-tokyo-night-storm
+++ b/themes/ghostty/base16-tokyo-night-storm
@@ -29,13 +29,15 @@ palette = 20=#787c99
 palette = 21=#cbccd1
 
 # Foreground & background colors
-background = 24283b
-foreground = a9b1d6
-cursor-color = a9b1d6
-selection-background = 343a52
-selection-foreground = a9b1d6
+background = #24283b
+foreground = #a9b1d6
+cursor-color = #a9b1d6
+selection-background = #343a52
+selection-foreground = #a9b1d6
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = a9b1d6
-macos-icon-screen-color = 24283b
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #d5d6db
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #2ac3de

--- a/themes/ghostty/base16-tokyo-night-terminal-dark
+++ b/themes/ghostty/base16-tokyo-night-terminal-dark
@@ -29,13 +29,15 @@ palette = 20=#787c99
 palette = 21=#cbccd1
 
 # Foreground & background colors
-background = 16161e
-foreground = 787c99
-cursor-color = 787c99
-selection-background = 2f3549
-selection-foreground = 787c99
+background = #16161e
+foreground = #787c99
+cursor-color = #787c99
+selection-background = #2f3549
+selection-foreground = #787c99
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 787c99
-macos-icon-screen-color = 16161e
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #d5d6db
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #7aa2f7

--- a/themes/ghostty/base16-tokyo-night-terminal-light
+++ b/themes/ghostty/base16-tokyo-night-terminal-light
@@ -29,13 +29,15 @@ palette = 20=#4c505e
 palette = 21=#1a1b26
 
 # Foreground & background colors
-background = d5d6db
-foreground = 4c505e
-cursor-color = 4c505e
-selection-background = dfe0e5
-selection-foreground = 4c505e
+background = #d5d6db
+foreground = #4c505e
+cursor-color = #4c505e
+selection-background = #dfe0e5
+selection-foreground = #4c505e
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 4c505e
-macos-icon-screen-color = d5d6db
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #1a1b26
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #34548a

--- a/themes/ghostty/base16-tokyo-night-terminal-storm
+++ b/themes/ghostty/base16-tokyo-night-terminal-storm
@@ -29,13 +29,15 @@ palette = 20=#787c99
 palette = 21=#cbccd1
 
 # Foreground & background colors
-background = 24283b
-foreground = 787c99
-cursor-color = 787c99
-selection-background = 343a52
-selection-foreground = 787c99
+background = #24283b
+foreground = #787c99
+cursor-color = #787c99
+selection-background = #343a52
+selection-foreground = #787c99
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 787c99
-macos-icon-screen-color = 24283b
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #d5d6db
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #7aa2f7

--- a/themes/ghostty/base16-tokyodark
+++ b/themes/ghostty/base16-tokyodark
@@ -29,13 +29,15 @@ palette = 20=#4a5057
 palette = 21=#abb2bf
 
 # Foreground & background colors
-background = 11121d
-foreground = a0a8cd
-cursor-color = a0a8cd
-selection-background = 212234
-selection-foreground = a0a8cd
+background = #11121d
+foreground = #a0a8cd
+cursor-color = #a0a8cd
+selection-background = #212234
+selection-foreground = #a0a8cd
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = a0a8cd
-macos-icon-screen-color = 11121d
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #bcc2dc
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #7199ee

--- a/themes/ghostty/base16-tokyodark-terminal
+++ b/themes/ghostty/base16-tokyodark-terminal
@@ -29,13 +29,15 @@ palette = 20=#4a5057
 palette = 21=#a0a8cd
 
 # Foreground & background colors
-background = 11121d
-foreground = a0a8cd
-cursor-color = a0a8cd
-selection-background = 212234
-selection-foreground = a0a8cd
+background = #11121d
+foreground = #a0a8cd
+cursor-color = #a0a8cd
+selection-background = #212234
+selection-foreground = #a0a8cd
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = a0a8cd
-macos-icon-screen-color = 11121d
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #a0a8cd
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #7199ee

--- a/themes/ghostty/base16-tomorrow
+++ b/themes/ghostty/base16-tomorrow
@@ -29,13 +29,15 @@ palette = 20=#969896
 palette = 21=#282a2e
 
 # Foreground & background colors
-background = ffffff
-foreground = 4d4d4c
-cursor-color = 4d4d4c
-selection-background = d6d6d6
-selection-foreground = 4d4d4c
+background = #ffffff
+foreground = #4d4d4c
+cursor-color = #4d4d4c
+selection-background = #d6d6d6
+selection-foreground = #4d4d4c
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 4d4d4c
-macos-icon-screen-color = ffffff
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #1d1f21
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #4271ae

--- a/themes/ghostty/base16-tomorrow-night
+++ b/themes/ghostty/base16-tomorrow-night
@@ -29,13 +29,15 @@ palette = 20=#b4b7b4
 palette = 21=#e0e0e0
 
 # Foreground & background colors
-background = 1d1f21
-foreground = c5c8c6
-cursor-color = c5c8c6
-selection-background = 373b41
-selection-foreground = c5c8c6
+background = #1d1f21
+foreground = #c5c8c6
+cursor-color = #c5c8c6
+selection-background = #373b41
+selection-foreground = #c5c8c6
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = c5c8c6
-macos-icon-screen-color = 1d1f21
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #81a2be

--- a/themes/ghostty/base16-tomorrow-night-eighties
+++ b/themes/ghostty/base16-tomorrow-night-eighties
@@ -29,13 +29,15 @@ palette = 20=#b4b7b4
 palette = 21=#e0e0e0
 
 # Foreground & background colors
-background = 2d2d2d
-foreground = cccccc
-cursor-color = cccccc
-selection-background = 515151
-selection-foreground = cccccc
+background = #2d2d2d
+foreground = #cccccc
+cursor-color = #cccccc
+selection-background = #515151
+selection-foreground = #cccccc
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = cccccc
-macos-icon-screen-color = 2d2d2d
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #6699cc

--- a/themes/ghostty/base16-tube
+++ b/themes/ghostty/base16-tube
@@ -29,13 +29,15 @@ palette = 20=#959ca1
 palette = 21=#e7e7e8
 
 # Foreground & background colors
-background = 231f20
-foreground = d9d8d8
-cursor-color = d9d8d8
-selection-background = 5a5758
-selection-foreground = d9d8d8
+background = #231f20
+foreground = #d9d8d8
+cursor-color = #d9d8d8
+selection-background = #5a5758
+selection-foreground = #d9d8d8
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = d9d8d8
-macos-icon-screen-color = 231f20
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #009ddc

--- a/themes/ghostty/base16-twilight
+++ b/themes/ghostty/base16-twilight
@@ -29,13 +29,15 @@ palette = 20=#838184
 palette = 21=#c3c3c3
 
 # Foreground & background colors
-background = 1e1e1e
-foreground = a7a7a7
-cursor-color = a7a7a7
-selection-background = 464b50
-selection-foreground = a7a7a7
+background = #1e1e1e
+foreground = #a7a7a7
+cursor-color = #a7a7a7
+selection-background = #464b50
+selection-foreground = #a7a7a7
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = a7a7a7
-macos-icon-screen-color = 1e1e1e
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #7587a6

--- a/themes/ghostty/base16-unikitty-dark
+++ b/themes/ghostty/base16-unikitty-dark
@@ -29,13 +29,15 @@ palette = 20=#9f9da2
 palette = 21=#d8d7da
 
 # Foreground & background colors
-background = 2e2a31
-foreground = bcbabe
-cursor-color = bcbabe
-selection-background = 666369
-selection-foreground = bcbabe
+background = #2e2a31
+foreground = #bcbabe
+cursor-color = #bcbabe
+selection-background = #666369
+selection-foreground = #bcbabe
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = bcbabe
-macos-icon-screen-color = 2e2a31
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #f5f4f7
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #796af5

--- a/themes/ghostty/base16-unikitty-light
+++ b/themes/ghostty/base16-unikitty-light
@@ -29,13 +29,15 @@ palette = 20=#89878b
 palette = 21=#4f4b51
 
 # Foreground & background colors
-background = ffffff
-foreground = 6c696e
-cursor-color = 6c696e
-selection-background = c4c3c5
-selection-foreground = 6c696e
+background = #ffffff
+foreground = #6c696e
+cursor-color = #6c696e
+selection-background = #c4c3c5
+selection-foreground = #6c696e
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 6c696e
-macos-icon-screen-color = ffffff
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #322d34
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #775dff

--- a/themes/ghostty/base16-unikitty-reversible
+++ b/themes/ghostty/base16-unikitty-reversible
@@ -29,13 +29,15 @@ palette = 20=#a5a3a6
 palette = 21=#e1e0e1
 
 # Foreground & background colors
-background = 2e2a31
-foreground = c3c2c4
-cursor-color = c3c2c4
-selection-background = 69666b
-selection-foreground = c3c2c4
+background = #2e2a31
+foreground = #c3c2c4
+cursor-color = #c3c2c4
+selection-background = #69666b
+selection-foreground = #c3c2c4
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = c3c2c4
-macos-icon-screen-color = 2e2a31
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #7864fa

--- a/themes/ghostty/base16-uwunicorn
+++ b/themes/ghostty/base16-uwunicorn
@@ -29,13 +29,15 @@ palette = 20=#7e5f83
 palette = 21=#d9c2c6
 
 # Foreground & background colors
-background = 241b26
-foreground = eed5d9
-cursor-color = eed5d9
-selection-background = 46354a
-selection-foreground = eed5d9
+background = #241b26
+foreground = #eed5d9
+cursor-color = #eed5d9
+selection-background = #46354a
+selection-foreground = #eed5d9
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = eed5d9
-macos-icon-screen-color = 241b26
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #e4ccd0
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #6a9eb5

--- a/themes/ghostty/base16-vesper
+++ b/themes/ghostty/base16-vesper
@@ -29,13 +29,15 @@ palette = 20=#999999
 palette = 21=#c1c1c1
 
 # Foreground & background colors
-background = 101010
-foreground = b7b7b7
-cursor-color = b7b7b7
-selection-background = 222222
-selection-foreground = b7b7b7
+background = #101010
+foreground = #b7b7b7
+cursor-color = #b7b7b7
+selection-background = #222222
+selection-foreground = #b7b7b7
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = b7b7b7
-macos-icon-screen-color = 101010
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #d5d5d5
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #8eaaaa

--- a/themes/ghostty/base16-vice
+++ b/themes/ghostty/base16-vice
@@ -29,13 +29,15 @@ palette = 20=#555e70
 palette = 21=#b2bfd9
 
 # Foreground & background colors
-background = 17191e
-foreground = 8b9cbe
-cursor-color = 8b9cbe
-selection-background = 3c3f4c
-selection-foreground = 8b9cbe
+background = #17191e
+foreground = #8b9cbe
+cursor-color = #8b9cbe
+selection-background = #3c3f4c
+selection-foreground = #8b9cbe
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 8b9cbe
-macos-icon-screen-color = 17191e
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #f4f4f7
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #00eaff

--- a/themes/ghostty/base16-vulcan
+++ b/themes/ghostty/base16-vulcan
@@ -29,13 +29,15 @@ palette = 20=#6b6977
 palette = 21=#333238
 
 # Foreground & background colors
-background = 041523
-foreground = 5b778c
-cursor-color = 5b778c
-selection-background = 003552
-selection-foreground = 5b778c
+background = #041523
+foreground = #5b778c
+cursor-color = #5b778c
+selection-background = #003552
+selection-foreground = #5b778c
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 5b778c
-macos-icon-screen-color = 041523
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #214d68
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #977d7c

--- a/themes/ghostty/base16-windows-10
+++ b/themes/ghostty/base16-windows-10
@@ -29,13 +29,15 @@ palette = 20=#b9b9b9
 palette = 21=#dfdfdf
 
 # Foreground & background colors
-background = 0c0c0c
-foreground = cccccc
-cursor-color = cccccc
-selection-background = 535353
-selection-foreground = cccccc
+background = #0c0c0c
+foreground = #cccccc
+cursor-color = #cccccc
+selection-background = #535353
+selection-foreground = #cccccc
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = cccccc
-macos-icon-screen-color = 0c0c0c
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #f2f2f2
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #3b78ff

--- a/themes/ghostty/base16-windows-10-light
+++ b/themes/ghostty/base16-windows-10-light
@@ -29,13 +29,15 @@ palette = 20=#ababab
 palette = 21=#414141
 
 # Foreground & background colors
-background = f2f2f2
-foreground = 767676
-cursor-color = 767676
-selection-background = d9d9d9
-selection-foreground = 767676
+background = #f2f2f2
+foreground = #767676
+cursor-color = #767676
+selection-background = #d9d9d9
+selection-foreground = #767676
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 767676
-macos-icon-screen-color = f2f2f2
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #0c0c0c
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #0037da

--- a/themes/ghostty/base16-windows-95
+++ b/themes/ghostty/base16-windows-95
@@ -29,13 +29,15 @@ palette = 20=#7e7e7e
 palette = 21=#d2d2d2
 
 # Foreground & background colors
-background = 000000
-foreground = a8a8a8
-cursor-color = a8a8a8
-selection-background = 383838
-selection-foreground = a8a8a8
+background = #000000
+foreground = #a8a8a8
+cursor-color = #a8a8a8
+selection-background = #383838
+selection-foreground = #a8a8a8
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = a8a8a8
-macos-icon-screen-color = 000000
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #fcfcfc
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #5454fc

--- a/themes/ghostty/base16-windows-95-light
+++ b/themes/ghostty/base16-windows-95-light
@@ -29,13 +29,15 @@ palette = 20=#7e7e7e
 palette = 21=#2a2a2a
 
 # Foreground & background colors
-background = fcfcfc
-foreground = 545454
-cursor-color = 545454
-selection-background = c4c4c4
-selection-foreground = 545454
+background = #fcfcfc
+foreground = #545454
+cursor-color = #545454
+selection-background = #c4c4c4
+selection-foreground = #545454
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 545454
-macos-icon-screen-color = fcfcfc
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #000000
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #0000a8

--- a/themes/ghostty/base16-windows-highcontrast
+++ b/themes/ghostty/base16-windows-highcontrast
@@ -29,13 +29,15 @@ palette = 20=#a2a2a2
 palette = 21=#dedede
 
 # Foreground & background colors
-background = 000000
-foreground = c0c0c0
-cursor-color = c0c0c0
-selection-background = 383838
-selection-foreground = c0c0c0
+background = #000000
+foreground = #c0c0c0
+cursor-color = #c0c0c0
+selection-background = #383838
+selection-foreground = #c0c0c0
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = c0c0c0
-macos-icon-screen-color = 000000
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #fcfcfc
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #5454fc

--- a/themes/ghostty/base16-windows-highcontrast-light
+++ b/themes/ghostty/base16-windows-highcontrast-light
@@ -29,13 +29,15 @@ palette = 20=#7e7e7e
 palette = 21=#2a2a2a
 
 # Foreground & background colors
-background = fcfcfc
-foreground = 545454
-cursor-color = 545454
-selection-background = d4d4d4
-selection-foreground = 545454
+background = #fcfcfc
+foreground = #545454
+cursor-color = #545454
+selection-background = #d4d4d4
+selection-foreground = #545454
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 545454
-macos-icon-screen-color = fcfcfc
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #000000
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #000080

--- a/themes/ghostty/base16-windows-nt
+++ b/themes/ghostty/base16-windows-nt
@@ -29,13 +29,15 @@ palette = 20=#a1a1a1
 palette = 21=#e0e0e0
 
 # Foreground & background colors
-background = 000000
-foreground = c0c0c0
-cursor-color = c0c0c0
-selection-background = 555555
-selection-foreground = c0c0c0
+background = #000000
+foreground = #c0c0c0
+cursor-color = #c0c0c0
+selection-background = #555555
+selection-foreground = #c0c0c0
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = c0c0c0
-macos-icon-screen-color = 000000
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #0000ff

--- a/themes/ghostty/base16-windows-nt-light
+++ b/themes/ghostty/base16-windows-nt-light
@@ -29,13 +29,15 @@ palette = 20=#a0a0a0
 palette = 21=#404040
 
 # Foreground & background colors
-background = ffffff
-foreground = 808080
-cursor-color = 808080
-selection-background = d5d5d5
-selection-foreground = 808080
+background = #ffffff
+foreground = #808080
+cursor-color = #808080
+selection-background = #d5d5d5
+selection-foreground = #808080
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 808080
-macos-icon-screen-color = ffffff
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #000000
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #000080

--- a/themes/ghostty/base16-woodland
+++ b/themes/ghostty/base16-woodland
@@ -29,13 +29,15 @@ palette = 20=#b4a490
 palette = 21=#d7c8bc
 
 # Foreground & background colors
-background = 231e18
-foreground = cabcb1
-cursor-color = cabcb1
-selection-background = 48413a
-selection-foreground = cabcb1
+background = #231e18
+foreground = #cabcb1
+cursor-color = #cabcb1
+selection-background = #48413a
+selection-foreground = #cabcb1
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = cabcb1
-macos-icon-screen-color = 231e18
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #e4d4c8
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #88a4d3

--- a/themes/ghostty/base16-xcode-dusk
+++ b/themes/ghostty/base16-xcode-dusk
@@ -29,13 +29,15 @@ palette = 20=#7e8086
 palette = 21=#a9aaae
 
 # Foreground & background colors
-background = 282b35
-foreground = 939599
-cursor-color = 939599
-selection-background = 53555d
-selection-foreground = 939599
+background = #282b35
+foreground = #939599
+cursor-color = #939599
+selection-background = #53555d
+selection-foreground = #939599
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 939599
-macos-icon-screen-color = 282b35
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #bebfc2
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #790ead

--- a/themes/ghostty/base16-zenbones
+++ b/themes/ghostty/base16-zenbones
@@ -29,13 +29,15 @@ palette = 20=#6099c0
 palette = 21=#66a5ad
 
 # Foreground & background colors
-background = 191919
-foreground = b279a7
-cursor-color = b279a7
-selection-background = 819b69
-selection-foreground = b279a7
+background = #191919
+foreground = #b279a7
+cursor-color = #b279a7
+selection-background = #819b69
+selection-foreground = #b279a7
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = b279a7
-macos-icon-screen-color = 191919
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #bbbbbb
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #cf86c1

--- a/themes/ghostty/base16-zenburn
+++ b/themes/ghostty/base16-zenburn
@@ -29,13 +29,15 @@ palette = 20=#808080
 palette = 21=#c0c0c0
 
 # Foreground & background colors
-background = 383838
-foreground = dcdccc
-cursor-color = dcdccc
-selection-background = 606060
-selection-foreground = dcdccc
+background = #383838
+foreground = #dcdccc
+cursor-color = #dcdccc
+selection-background = #606060
+selection-foreground = #dcdccc
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = dcdccc
-macos-icon-screen-color = 383838
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #7cb8bb

--- a/themes/ghostty/base24-brogrammer
+++ b/themes/ghostty/base24-brogrammer
@@ -29,13 +29,15 @@ palette = 20=#d6dae4
 palette = 21=#e3e6ed
 
 # Foreground & background colors
-background = 131313
-foreground = c1c8d7
-cursor-color = c1c8d7
-selection-background = 2a3141
-selection-foreground = c1c8d7
+background = #131313
+foreground = #c1c8d7
+cursor-color = #c1c8d7
+selection-background = #2a3141
+selection-foreground = #c1c8d7
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = c1c8d7
-macos-icon-screen-color = 131313
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #509bdc

--- a/themes/ghostty/base24-catppuccin-frappe
+++ b/themes/ghostty/base24-catppuccin-frappe
@@ -29,13 +29,15 @@ palette = 20=#626880
 palette = 21=#f2d5cf
 
 # Foreground & background colors
-background = 303446
-foreground = c6d0f5
-cursor-color = c6d0f5
-selection-background = 414559
-selection-foreground = c6d0f5
+background = #303446
+foreground = #c6d0f5
+cursor-color = #c6d0f5
+selection-background = #414559
+selection-foreground = #c6d0f5
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = c6d0f5
-macos-icon-screen-color = 303446
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #babbf1
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #85c1dc

--- a/themes/ghostty/base24-catppuccin-latte
+++ b/themes/ghostty/base24-catppuccin-latte
@@ -29,13 +29,15 @@ palette = 20=#acb0be
 palette = 21=#dc8a78
 
 # Foreground & background colors
-background = eff1f5
-foreground = 4c4f69
-cursor-color = 4c4f69
-selection-background = ccd0da
-selection-foreground = 4c4f69
+background = #eff1f5
+foreground = #4c4f69
+cursor-color = #4c4f69
+selection-background = #ccd0da
+selection-foreground = #4c4f69
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 4c4f69
-macos-icon-screen-color = eff1f5
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #7287fd
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #209fb5

--- a/themes/ghostty/base24-catppuccin-macchiato
+++ b/themes/ghostty/base24-catppuccin-macchiato
@@ -29,13 +29,15 @@ palette = 20=#5b6078
 palette = 21=#f4dbd6
 
 # Foreground & background colors
-background = 24273a
-foreground = cad3f5
-cursor-color = cad3f5
-selection-background = 363a4f
-selection-foreground = cad3f5
+background = #24273a
+foreground = #cad3f5
+cursor-color = #cad3f5
+selection-background = #363a4f
+selection-foreground = #cad3f5
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = cad3f5
-macos-icon-screen-color = 24273a
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #b7bdf8
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #7dc4e4

--- a/themes/ghostty/base24-catppuccin-mocha
+++ b/themes/ghostty/base24-catppuccin-mocha
@@ -29,13 +29,15 @@ palette = 20=#585b70
 palette = 21=#f5e0dc
 
 # Foreground & background colors
-background = 1e1e2e
-foreground = cdd6f4
-cursor-color = cdd6f4
-selection-background = 313244
-selection-foreground = cdd6f4
+background = #1e1e2e
+foreground = #cdd6f4
+cursor-color = #cdd6f4
+selection-background = #313244
+selection-foreground = #cdd6f4
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = cdd6f4
-macos-icon-screen-color = 1e1e2e
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #b4befe
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #74c7ec

--- a/themes/ghostty/base24-chalk
+++ b/themes/ghostty/base24-chalk
@@ -29,13 +29,15 @@ palette = 20=#b0b0b0
 palette = 21=#e0e0e0
 
 # Foreground & background colors
-background = 151515
-foreground = d0d0d0
-cursor-color = d0d0d0
-selection-background = 303030
-selection-foreground = d0d0d0
+background = #151515
+foreground = #d0d0d0
+cursor-color = #d0d0d0
+selection-background = #303030
+selection-foreground = #d0d0d0
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = d0d0d0
-macos-icon-screen-color = 151515
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #f5f5f5
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #6fc2ef

--- a/themes/ghostty/base24-deep-oceanic-next
+++ b/themes/ghostty/base24-deep-oceanic-next
@@ -1,41 +1,43 @@
 # vim: ft=ghostty
 # Deep Oceanic Next theme for Ghostty
-# Scheme Author: spearkkk (https://github.com/spearkkk/deep-oceanic-next)
+# Scheme Author: spearkkk (https://github.com/spearkkk)
 # Scheme System: base24
 # Template Author: Tinted Terminal (https://github.com/tinted-theming/tinted-terminal)
 
 # Color palette
-palette = 0=#003b46
-palette = 1=#e6454b
-palette = 2=#85b57a
-palette = 3=#ffcc66
-palette = 4=#3a82e6
-palette = 5=#8c4de6
-palette = 6=#4da6a6
-palette = 7=#e6ebf0
-palette = 8=#006374
-palette = 9=#ff5a61
-palette = 10=#99d8a0
-palette = 11=#ffdd80
-palette = 12=#4da6ff
-palette = 13=#a366ff
-palette = 14=#66cccc
-palette = 15=#f0f5f5
-palette = 16=#ff6a4b
-palette = 17=#e673a3
-palette = 18=#004f5e
-palette = 19=#006374
+palette = 0=#001c1f
+palette = 1=#d3464d
+palette = 2=#63b784
+palette = 3=#f3b863
+palette = 4=#568ccf
+palette = 5=#8b66d6
+palette = 6=#4fb7ae
+palette = 7=#e0e9ef
+palette = 8=#003640
+palette = 9=#ff6670
+palette = 10=#72e1a6
+palette = 11=#ffe08a
+palette = 12=#5caeff
+palette = 13=#b788ff
+palette = 14=#4de3e3
+palette = 15=#f2f7f9
+palette = 16=#e37552
+palette = 17=#d0658e
+palette = 18=#002931
+palette = 19=#003640
 palette = 20=#0093a3
-palette = 21=#e6ebf0
+palette = 21=#e0e9ef
 
 # Foreground & background colors
-background = 003b46
-foreground = dce3e8
-cursor-color = dce3e8
-selection-background = 006374
-selection-foreground = dce3e8
+background = #001c1f
+foreground = #d4e1e8
+cursor-color = #d4e1e8
+selection-background = #003640
+selection-foreground = #d4e1e8
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = dce3e8
-macos-icon-screen-color = 003b46
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #f2f7f9
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #5caeff

--- a/themes/ghostty/base24-dracula
+++ b/themes/ghostty/base24-dracula
@@ -29,13 +29,15 @@ palette = 20=#9ea8c7
 palette = 21=#f0f1f4
 
 # Foreground & background colors
-background = 282a36
-foreground = f8f8f2
-cursor-color = f8f8f2
-selection-background = 44475a
-selection-foreground = f8f8f2
+background = #282a36
+foreground = #f8f8f2
+cursor-color = #f8f8f2
+selection-background = #44475a
+selection-foreground = #f8f8f2
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = f8f8f2
-macos-icon-screen-color = 282a36
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #a3ccf5

--- a/themes/ghostty/base24-espresso
+++ b/themes/ghostty/base24-espresso
@@ -29,13 +29,15 @@ palette = 20=#a0a09f
 palette = 21=#eeeeec
 
 # Foreground & background colors
-background = 262626
-foreground = c7c7c5
-cursor-color = c7c7c5
-selection-background = 535353
-selection-foreground = c7c7c5
+background = #262626
+foreground = #c7c7c5
+cursor-color = #c7c7c5
+selection-background = #535353
+selection-foreground = #c7c7c5
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = c7c7c5
-macos-icon-screen-color = 262626
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #8ab7d9

--- a/themes/ghostty/base24-flat
+++ b/themes/ghostty/base24-flat
@@ -29,13 +29,15 @@ palette = 20=#68717b
 palette = 21=#b0b6ba
 
 # Foreground & background colors
-background = 082845
-foreground = 8c939a
-cursor-color = 8c939a
-selection-background = 2e2e45
-selection-foreground = 8c939a
+background = #082845
+foreground = #8c939a
+cursor-color = #8c939a
+selection-background = #2e2e45
+selection-foreground = #8c939a
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 8c939a
-macos-icon-screen-color = 082845
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #e7eced
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #3c7dd2

--- a/themes/ghostty/base24-framer
+++ b/themes/ghostty/base24-framer
@@ -29,13 +29,15 @@ palette = 20=#868686
 palette = 21=#cccccc
 
 # Foreground & background colors
-background = 111111
-foreground = a9a9a9
-cursor-color = a9a9a9
-selection-background = 414141
-selection-foreground = a9a9a9
+background = #111111
+foreground = #a9a9a9
+cursor-color = #a9a9a9
+selection-background = #414141
+selection-foreground = #a9a9a9
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = a9a9a9
-macos-icon-screen-color = 111111
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #33bbff

--- a/themes/ghostty/base24-github
+++ b/themes/ghostty/base24-github
@@ -29,13 +29,15 @@ palette = 20=#b2b2b2
 palette = 21=#ffffff
 
 # Foreground & background colors
-background = f4f4f4
-foreground = d8d8d8
-cursor-color = d8d8d8
-selection-background = 666666
-selection-foreground = d8d8d8
+background = #f4f4f4
+foreground = #d8d8d8
+cursor-color = #d8d8d8
+selection-background = #666666
+selection-foreground = #d8d8d8
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = d8d8d8
-macos-icon-screen-color = f4f4f4
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #2e6cba

--- a/themes/ghostty/base24-hardcore
+++ b/themes/ghostty/base24-hardcore
@@ -29,13 +29,15 @@ palette = 20=#868686
 palette = 21=#cccccc
 
 # Foreground & background colors
-background = 111111
-foreground = a9a9a9
-cursor-color = a9a9a9
-selection-background = 414141
-selection-foreground = a9a9a9
+background = #111111
+foreground = #a9a9a9
+cursor-color = #a9a9a9
+selection-background = #414141
+selection-foreground = #a9a9a9
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = a9a9a9
-macos-icon-screen-color = 111111
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #33bbff

--- a/themes/ghostty/base24-one-black
+++ b/themes/ghostty/base24-one-black
@@ -29,13 +29,15 @@ palette = 20=#9196a1
 palette = 21=#e6e6e6
 
 # Foreground & background colors
-background = 000000
-foreground = abb2bf
-cursor-color = abb2bf
-selection-background = 4f5666
-selection-foreground = abb2bf
+background = #000000
+foreground = #abb2bf
+cursor-color = #abb2bf
+selection-background = #4f5666
+selection-foreground = #abb2bf
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = abb2bf
-macos-icon-screen-color = 000000
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #4dc4ff

--- a/themes/ghostty/base24-one-dark
+++ b/themes/ghostty/base24-one-dark
@@ -29,13 +29,15 @@ palette = 20=#9196a1
 palette = 21=#e6e6e6
 
 # Foreground & background colors
-background = 282c34
-foreground = abb2bf
-cursor-color = abb2bf
-selection-background = 4f5666
-selection-foreground = abb2bf
+background = #282c34
+foreground = #abb2bf
+cursor-color = #abb2bf
+selection-background = #4f5666
+selection-foreground = #abb2bf
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = abb2bf
-macos-icon-screen-color = 282c34
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #4dc4ff

--- a/themes/ghostty/base24-one-light
+++ b/themes/ghostty/base24-one-light
@@ -29,13 +29,15 @@ palette = 20=#696c77
 palette = 21=#202227
 
 # Foreground & background colors
-background = e7e7e9
-foreground = 383a42
-cursor-color = 383a42
-selection-background = cacace
-selection-foreground = 383a42
+background = #e7e7e9
+foreground = #383a42
+cursor-color = #383a42
+selection-background = #cacace
+selection-foreground = #383a42
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = 383a42
-macos-icon-screen-color = e7e7e9
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #090a0b
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #709af5

--- a/themes/ghostty/base24-sparky
+++ b/themes/ghostty/base24-sparky
@@ -29,13 +29,15 @@ palette = 20=#00778b
 palette = 21=#f5f5f1
 
 # Foreground & background colors
-background = 072b31
-foreground = f4f5f0
-cursor-color = f4f5f0
-selection-background = 003c46
-selection-foreground = f4f5f0
+background = #072b31
+foreground = #f4f5f0
+cursor-color = #f4f5f0
+selection-background = #003c46
+selection-foreground = #f4f5f0
 
-# Match the macOS icon w/ the foreground & background colors
-# Set `macos-icon = custom-style` in your main configuration file to enable
-macos-icon-ghost-color = f4f5f0
-macos-icon-screen-color = 072b31
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+#
+# Set the ghost color to the lightest foreground:
+macos-icon-ghost-color = #ffffff
+# Replace the official icon's blue background with the designated bright blue color:
+macos-icon-screen-color = #69b3e7


### PR DESCRIPTION
1. Ghostty understands hex colors w/o the `#`, but adding it in make color hints work better on the theme files e.g.

<img width="788" alt="SCR-20241231-cfuq" src="https://github.com/user-attachments/assets/2a72cbbf-6d04-4627-8920-718c98722c53" />

2. Use the theme's `Bright Blue` to replace the blue background of the official icon