### PR TITLE
feat: configurable `macos-icon-*-color` in Ghostty themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,46 @@ theme = base16-ayu-dark
 > [!IMPORTANT]
 > You will need to trigger `reload_config` in Ghostty for the palette to apply. The default keybinding for this is `Cmd + Shift + ,` for macOS, or `Ctrl + Shift + ,` for Linux/Windows
 
+
+### Customize style for Ghostty's app icon (macOS only)
+
+By default, the theme files assigns `Bright White` and `Bright Blue` for the icon's ghost tint and screen tint,
+respectively. If you'd like to use different colors, this repository provides scripts to generate a theme file with the 
+icon & screen tints you prefer. They are located in `./themes/ghostty-scripts` and can be used as follows:
+
+#### Manual
+
+```sh
+# Example:
+sh /path/to/tinted-terminal/themes/ghostty-scripts/base16-ayu-dark.sh \
+   -g 5 \
+   -s 16,12,10 \
+   >! ~/.config/ghostty/themes/base16-ayu-dark
+```
+
+The above example would generate a `base16-ayu-dark` theme with `macos-icon-ghost-color` set to `palette[5]` color, and
+`macos-icon-screen-color` set to a gradient of `palette[16]`, `palette[12]`, and `palette[10]`.
+
+#### Tinty
+
+Follow the same [Tinty instructions](#tinty-2), but put this in `~/.config/tinted-theming/tinty/config.toml` instead for
+Step 2:
+
+```toml
+[[items]]
+path = "https://github.com/tinted-theming/tinted-terminal"
+name = "tinted-terminal"
+themes-dir = "themes/ghostty-scripts"
+# With `theme` set to "tinted-theming", this will be where Ghostty looks for the theme file:
+hook = '''
+sh %f \
+   -g 5 \
+   -s 16,12,10 \
+   >! ~/.config/ghostty/themes/tinted-theming
+'''
+supported-systems = ["base16", "base24"]
+```
+
 ## iTerm2
 
 <img src="./assets/iterm2-icon.png" alt="iTerm2 terminal logo" width="50"/>

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ theme = base16-ayu-dark
 > You will need to trigger `reload_config` in Ghostty for the palette to apply. The default keybinding for this is `Cmd + Shift + ,` for macOS, or `Ctrl + Shift + ,` for Linux/Windows
 
 
-### Customize style for Ghostty's app icon (macOS only)
+### Customize Ghostty's app icon (macOS only)
 
 By default, the theme files assigns `Bright White` and `Bright Blue` for the icon's ghost tint and screen tint,
 respectively. If you'd like to use different colors, this repository provides scripts to generate a theme file with the 
@@ -380,6 +380,12 @@ sh %f \
    >! ~/.config/ghostty/themes/tinted-theming
 '''
 supported-systems = ["base16", "base24"]
+```
+
+Don’t forget to have this line on your main Ghostty configuration:
+
+```ini
+macos-icon = custom-style
 ```
 
 ## iTerm2

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -38,6 +38,14 @@ ghostty-base24:
   filename: themes/ghostty/{{ scheme-system }}-{{ scheme-slug }}
   supported-systems: [base24]
 
+ghostty-script-base16:
+  filename: themes/ghostty-scripts/{{ scheme-system }}-{{ scheme-slug }}.sh
+  supported-systems: [base16]
+  
+ghostty-script-base24:
+  filename: themes/ghostty-scripts/{{ scheme-system }}-{{ scheme-slug }}.sh
+  supported-systems: [base24]
+
 # iTerm2
 # ----------------------------------------------------------------------
 iterm2-base16:

--- a/templates/ghostty-script-base16.mustache
+++ b/templates/ghostty-script-base16.mustache
@@ -82,7 +82,7 @@ cursor-color = $ghostty_palette_color_7
 selection-background = $ghostty_palette_color_8
 selection-foreground = $ghostty_palette_color_7
 
-# Set macos-icon = custom-style in your main configuration file to enable theming of the app icon.
+# Set \`macos-icon\` = custom-style in your main configuration file to enable theming of the app icon.
 EOF
 }
 
@@ -170,7 +170,7 @@ eval set -- "$OPTS"
 ghost_color_arg=15 # Default ghost color to Bright White
 screen_colors_arg=12 # Default screen color to Bright Blue
 
-while [[ -n "$1" ]]; do
+while [ -n "$1" ]; do
     case "$1" in
         -g)
             ghost_color_arg="$2"

--- a/templates/ghostty-script-base16.mustache
+++ b/templates/ghostty-script-base16.mustache
@@ -1,16 +1,7 @@
 #!/usr/bin/env sh
+# vim: ft=sh
 
-# ===================
-# ghostty-icon-tinter
-# ===================
-
-function _extract_palette_value {
-    # Note: return the last recurrence, in case there are multiple.
-    _theme_file | sed -nE 's/palette = '$1'=(#.*)/\1/p' \
-       | tail -n 1
-}
-
-function _help {
+_help {
     2>&1 cat <<EOF
 Generates a Ghostty theme file with macos-icon-ghost-color and macos-icon-screen-color directives
 based on an existing theme. This script is mainly designed to be used with tinted-theming/tinty.
@@ -28,7 +19,31 @@ OPTIONS:
 EOF
 }
 
-function _theme_file {
+
+ghostty_palette_color_0="#{{ base00-hex }}"
+ghostty_palette_color_1="#{{ base08-hex }}"
+ghostty_palette_color_2="#{{ base0B-hex }}"
+ghostty_palette_color_3="#{{ base0A-hex }}"
+ghostty_palette_color_4="#{{ base0D-hex }}"
+ghostty_palette_color_5="#{{ base0E-hex }}"
+ghostty_palette_color_6="#{{ base0C-hex }}"
+ghostty_palette_color_7="#{{ base05-hex }}"
+ghostty_palette_color_8="#{{ base02-hex }}"
+ghostty_palette_color_9="#{{ base08-hex }}"
+ghostty_palette_color_10="#{{ base0B-hex }}"
+ghostty_palette_color_11="#{{ base0A-hex }}"
+ghostty_palette_color_12="#{{ base0D-hex }}"
+ghostty_palette_color_13="#{{ base0E-hex }}"
+ghostty_palette_color_14="#{{ base0C-hex }}"
+ghostty_palette_color_15="#{{ base07-hex }}"
+ghostty_palette_color_16="#{{ base09-hex }}"
+ghostty_palette_color_17="#{{ base0F-hex }}"
+ghostty_palette_color_18="#{{ base01-hex }}"
+ghostty_palette_color_19="#{{ base02-hex }}"
+ghostty_palette_color_20="#{{ base04-hex }}"
+ghostty_palette_color_21="#{{ base06-hex }}"
+
+_theme_file {
 cat <<EOF
 # vim: ft=ghostty
 # {{ scheme-name }} theme for Ghostty
@@ -37,39 +52,114 @@ cat <<EOF
 # Template Author: Tinted Terminal (https://github.com/tinted-theming/tinted-terminal)
 
 # Color palette
-palette = 0=#{{ base00-hex }}
-palette = 1=#{{ base08-hex }}
-palette = 2=#{{ base0B-hex }}
-palette = 3=#{{ base0A-hex }}
-palette = 4=#{{ base0D-hex }}
-palette = 5=#{{ base0E-hex }}
-palette = 6=#{{ base0C-hex }}
-palette = 7=#{{ base05-hex }}
-palette = 8=#{{ base02-hex }}
-palette = 9=#{{ base08-hex }}
-palette = 10=#{{ base0B-hex }}
-palette = 11=#{{ base0A-hex }}
-palette = 12=#{{ base0D-hex }}
-palette = 13=#{{ base0E-hex }}
-palette = 14=#{{ base0C-hex }}
-palette = 15=#{{ base07-hex }}
-palette = 16=#{{ base09-hex }}
-palette = 17=#{{ base0F-hex }}
-palette = 18=#{{ base01-hex }}
-palette = 19=#{{ base02-hex }}
-palette = 20=#{{ base04-hex }}
-palette = 21=#{{ base06-hex }}
+palette = 0=$ghostty_palette_color_0
+palette = 1=$ghostty_palette_color_1
+palette = 2=$ghostty_palette_color_2
+palette = 3=$ghostty_palette_color_3
+palette = 4=$ghostty_palette_color_4
+palette = 5=$ghostty_palette_color_5
+palette = 6=$ghostty_palette_color_6
+palette = 7=$ghostty_palette_color_7
+palette = 8=$ghostty_palette_color_8
+palette = 9=$ghostty_palette_color_9
+palette = 10=$ghostty_palette_color_10
+palette = 11=$ghostty_palette_color_11
+palette = 12=$ghostty_palette_color_12
+palette = 13=$ghostty_palette_color_13
+palette = 14=$ghostty_palette_color_14
+palette = 15=$ghostty_palette_color_15
+palette = 16=$ghostty_palette_color_16
+palette = 17=$ghostty_palette_color_17
+palette = 18=$ghostty_palette_color_18
+palette = 19=$ghostty_palette_color_19
+palette = 20=$ghostty_palette_color_20
+palette = 21=$ghostty_palette_color_21
 
 # Foreground & background colors
-background = #{{ base00-hex }}
-foreground = #{{ base05-hex }}
-cursor-color = #{{ base05-hex }}
-selection-background = #{{ base02-hex }}
-selection-foreground = #{{ base05-hex }}
+background = $ghostty_palette_color_0
+foreground = $ghostty_palette_color_7
+cursor-color = $ghostty_palette_color_7
+selection-background = $ghostty_palette_color_8
+selection-foreground = $ghostty_palette_color_7
 
 # Set macos-icon = custom-style in your main configuration file to enable theming of the app icon.
 EOF
 }
+
+_palette_value {
+    # Indirect expansion is not POSIX-compliant. Writing this as a switch-case avoids using eval and injection risks that
+    # comes with it.
+    case "$1" in
+        "0") echo $ghostty_palette_color_0
+            break
+            ;;
+        "1") echo $ghostty_palette_color_1
+            break
+            ;;
+        "2") echo $ghostty_palette_color_2
+            break
+            ;;
+        "3") echo $ghostty_palette_color_3
+            break
+            ;;
+        "4") echo $ghostty_palette_color_4
+            break
+            ;;
+        "5") echo $ghostty_palette_color_5
+            break
+            ;;
+        "6") echo $ghostty_palette_color_6
+            break
+            ;;
+        "7") echo $ghostty_palette_color_7
+            break
+            ;;
+        "8") echo $ghostty_palette_color_8
+            break
+            ;;
+        "9") echo $ghostty_palette_color_9
+            break
+            ;;
+        "10") echo $ghostty_palette_color_10
+            break
+            ;;
+        "11") echo $ghostty_palette_color_11
+            break
+            ;;
+        "12") echo $ghostty_palette_color_12
+            break
+            ;;
+        "13") echo $ghostty_palette_color_13
+            break
+            ;;
+        "14") echo $ghostty_palette_color_14
+            break
+            ;;
+        "15") echo $ghostty_palette_color_15
+            break
+            ;;
+        "16") echo $ghostty_palette_color_16
+            break
+            ;;
+        "17") echo $ghostty_palette_color_17
+            break
+            ;;
+        "18") echo $ghostty_palette_color_18
+            break
+            ;;
+        "19") echo $ghostty_palette_color_19
+            break
+            ;;
+        "20") echo $ghostty_palette_color_20
+            break
+            ;;
+        "21") echo $ghostty_palette_color_21
+            break
+            ;;
+    esac
+}
+
+
 
 OPTIND=1
 
@@ -83,11 +173,11 @@ screen_colors_arg=12 # Default screen color to Bright Blue
 while [[ -n "$1" ]]; do
     case "$1" in
         -g)
-            ghost_color_arg=$2
+            ghost_color_arg="$2"
             shift 2
             ;;
         -s)
-            screen_colors_arg=$2
+            screen_colors_arg="$2"
             shift 2
             ;;
         --)
@@ -107,7 +197,7 @@ while [[ -n "$1" ]]; do
 done
 
 screen_color_values=
-ghost_color_value=$(_extract_palette_value $ghost_color_arg)
+ghost_color_value=$(_palette_value $ghost_color_arg)
 
 _theme_file
 
@@ -121,18 +211,18 @@ fi
 screen_color_values=$(
     o=
     echo $screen_colors_arg | tr ',' "\n" | while read c; do
-        color_value=$(_extract_palette_value $c)
+        color_value=$(_palette_value $c)
         if [ -n "$color_value" ]; then
-            if [[ -n "$o" ]]; then
-                color_value=",${color_value}"
+            if [ -n "$o" ]; then
+                color_value=",$color_value"
             fi
-            o="${o}${color_value}"
-            echo $o
+            o="$o$color_value"
+            echo "$o"
         fi
     done | tail -n 1
 )
 
 if [ -n "$screen_color_values" ]; then
-    echo "# Extracted palette colors ${screen_colors_arg}:"
-    echo "macos-icon-screen-color = ${screen_color_values}"
+    echo "# Extracted palette colors $screen_colors_arg:"
+    echo "macos-icon-screen-color = $screen_color_values"
 fi

--- a/templates/ghostty-script-base16.mustache
+++ b/templates/ghostty-script-base16.mustache
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 # vim: ft=sh
 
-_help {
+_help() {
     2>&1 cat <<EOF
 Generates a Ghostty theme file with macos-icon-ghost-color and macos-icon-screen-color directives
 based on an existing theme. This script is mainly designed to be used with tinted-theming/tinty.
@@ -43,7 +43,7 @@ ghostty_palette_color_19="#{{ base02-hex }}"
 ghostty_palette_color_20="#{{ base04-hex }}"
 ghostty_palette_color_21="#{{ base06-hex }}"
 
-_theme_file {
+_theme_file() {
 cat <<EOF
 # vim: ft=ghostty
 # {{ scheme-name }} theme for Ghostty
@@ -86,7 +86,7 @@ selection-foreground = $ghostty_palette_color_7
 EOF
 }
 
-_palette_value {
+_palette_value() {
     # Indirect expansion is not POSIX-compliant. Writing this as a switch-case avoids using eval and injection risks that
     # comes with it.
     case "$1" in

--- a/templates/ghostty-script-base16.mustache
+++ b/templates/ghostty-script-base16.mustache
@@ -1,0 +1,138 @@
+#!/usr/bin/env sh
+
+# ===================
+# ghostty-icon-tinter
+# ===================
+
+function _extract_palette_value {
+    # Note: return the last recurrence, in case there are multiple.
+    _theme_file | sed -nE 's/palette = '$1'=(#.*)/\1/p' \
+       | tail -n 1
+}
+
+function _help {
+    2>&1 cat <<EOF
+Generates a Ghostty theme file with macos-icon-ghost-color and macos-icon-screen-color directives
+based on an existing theme. This script is mainly designed to be used with tinted-theming/tinty.
+
+OPTIONS:
+
+    -g palette_index
+    	Use palette[palette_index] as macos-icon-ghost-color
+
+    -s palette_index|palette_indices
+
+        Use palette[palette_index] as macos-icon-screen-color. 
+        If you wish the screen color to be a gradient, specify a comma-separated list of 
+        indices e.g. -s 12,6,2
+EOF
+}
+
+function _theme_file {
+cat <<EOF
+# vim: ft=ghostty
+# {{ scheme-name }} theme for Ghostty
+# Scheme Author: {{ scheme-author }}
+# Scheme System: {{ scheme-system }}
+# Template Author: Tinted Terminal (https://github.com/tinted-theming/tinted-terminal)
+
+# Color palette
+palette = 0=#{{ base00-hex }}
+palette = 1=#{{ base08-hex }}
+palette = 2=#{{ base0B-hex }}
+palette = 3=#{{ base0A-hex }}
+palette = 4=#{{ base0D-hex }}
+palette = 5=#{{ base0E-hex }}
+palette = 6=#{{ base0C-hex }}
+palette = 7=#{{ base05-hex }}
+palette = 8=#{{ base02-hex }}
+palette = 9=#{{ base08-hex }}
+palette = 10=#{{ base0B-hex }}
+palette = 11=#{{ base0A-hex }}
+palette = 12=#{{ base0D-hex }}
+palette = 13=#{{ base0E-hex }}
+palette = 14=#{{ base0C-hex }}
+palette = 15=#{{ base07-hex }}
+palette = 16=#{{ base09-hex }}
+palette = 17=#{{ base0F-hex }}
+palette = 18=#{{ base01-hex }}
+palette = 19=#{{ base02-hex }}
+palette = 20=#{{ base04-hex }}
+palette = 21=#{{ base06-hex }}
+
+# Foreground & background colors
+background = #{{ base00-hex }}
+foreground = #{{ base05-hex }}
+cursor-color = #{{ base05-hex }}
+selection-background = #{{ base02-hex }}
+selection-foreground = #{{ base05-hex }}
+
+# Set macos-icon = custom-style in your main configuration file to enable theming of the app icon.
+EOF
+}
+
+OPTIND=1
+
+OPTS=$(getopt g:s:h $*) || exit 2
+
+eval set -- "$OPTS"
+
+ghost_color_arg=15 # Default ghost color to Bright White
+screen_colors_arg=12 # Default screen color to Bright Blue
+
+while [[ -n "$1" ]]; do
+    case "$1" in
+        -g)
+            ghost_color_arg=$2
+            shift 2
+            ;;
+        -s)
+            screen_colors_arg=$2
+            shift 2
+            ;;
+        --)
+            shift
+            break
+            ;;
+        -h)
+            shift
+            _help
+            exit 0
+            ;;
+        -h)
+            _help
+            exit 1
+            ;;
+    esac
+done
+
+screen_color_values=
+ghost_color_value=$(_extract_palette_value $ghost_color_arg)
+
+_theme_file
+
+if [ -n "$ghost_color_value" ]; then
+    echo "# Extracted palette color $ghost_color_arg:"
+    echo "macos-icon-ghost-color = $ghost_color_value"
+fi
+
+# Parse comma-separated string in POSIX-compliant way
+# TODO: There has to be a better way to do this.
+screen_color_values=$(
+    o=
+    echo $screen_colors_arg | tr ',' "\n" | while read c; do
+        color_value=$(_extract_palette_value $c)
+        if [ -n "$color_value" ]; then
+            if [[ -n "$o" ]]; then
+                color_value=",${color_value}"
+            fi
+            o="${o}${color_value}"
+            echo $o
+        fi
+    done | tail -n 1
+)
+
+if [ -n "$screen_color_values" ]; then
+    echo "# Extracted palette colors ${screen_colors_arg}:"
+    echo "macos-icon-screen-color = ${screen_color_values}"
+fi

--- a/templates/ghostty-script-base24.mustache
+++ b/templates/ghostty-script-base24.mustache
@@ -1,16 +1,7 @@
 #!/usr/bin/env sh
+# vim: ft=sh
 
-# ===================
-# ghostty-icon-tinter
-# ===================
-
-function _extract_palette_value {
-    # Note: return the last recurrence, in case there are multiple.
-    _theme_file | sed -nE 's/palette = '$1'=(#.*)/\1/p' \
-       | tail -n 1
-}
-
-function _help {
+_help {
     2>&1 cat <<EOF
 Generates a Ghostty theme file with macos-icon-ghost-color and macos-icon-screen-color directives
 based on an existing theme. This script is mainly designed to be used with tinted-theming/tinty.
@@ -28,7 +19,31 @@ OPTIONS:
 EOF
 }
 
-function _theme_file {
+
+ghostty_palette_color_0="#{{ base00-hex }}"
+ghostty_palette_color_1="#{{ base08-hex }}"
+ghostty_palette_color_2="#{{ base0B-hex }}"
+ghostty_palette_color_3="#{{ base0A-hex }}"
+ghostty_palette_color_4="#{{ base0D-hex }}"
+ghostty_palette_color_5="#{{ base0E-hex }}"
+ghostty_palette_color_6="#{{ base0C-hex }}"
+ghostty_palette_color_7="#{{ base06-hex }}"
+ghostty_palette_color_8="#{{ base02-hex }}"
+ghostty_palette_color_9="#{{ base12-hex }}"
+ghostty_palette_color_10="#{{ base14-hex }}"
+ghostty_palette_color_11="#{{ base13-hex }}"
+ghostty_palette_color_12="#{{ base16-hex }}"
+ghostty_palette_color_13="#{{ base17-hex }}"
+ghostty_palette_color_14="#{{ base15-hex }}"
+ghostty_palette_color_15="#{{ base07-hex }}"
+ghostty_palette_color_16="#{{ base09-hex }}"
+ghostty_palette_color_17="#{{ base0F-hex }}"
+ghostty_palette_color_18="#{{ base01-hex }}"
+ghostty_palette_color_19="#{{ base02-hex }}"
+ghostty_palette_color_20="#{{ base04-hex }}"
+ghostty_palette_color_21="#{{ base06-hex }}"
+
+_theme_file {
 cat <<EOF
 # vim: ft=ghostty
 # {{ scheme-name }} theme for Ghostty
@@ -37,39 +52,114 @@ cat <<EOF
 # Template Author: Tinted Terminal (https://github.com/tinted-theming/tinted-terminal)
 
 # Color palette
-palette = 0=#{{ base00-hex }}
-palette = 1=#{{ base08-hex }}
-palette = 2=#{{ base0B-hex }}
-palette = 3=#{{ base0A-hex }}
-palette = 4=#{{ base0D-hex }}
-palette = 5=#{{ base0E-hex }}
-palette = 6=#{{ base0C-hex }}
-palette = 7=#{{ base06-hex }}
-palette = 8=#{{ base02-hex }}
-palette = 9=#{{ base12-hex }}
-palette = 10=#{{ base14-hex }}
-palette = 11=#{{ base13-hex }}
-palette = 12=#{{ base16-hex }}
-palette = 13=#{{ base17-hex }}
-palette = 14=#{{ base15-hex }}
-palette = 15=#{{ base07-hex }}
-palette = 16=#{{ base09-hex }}
-palette = 17=#{{ base0F-hex }}
-palette = 18=#{{ base01-hex }}
-palette = 19=#{{ base02-hex }}
-palette = 20=#{{ base04-hex }}
-palette = 21=#{{ base06-hex }}
+palette = 0=$ghostty_palette_color_0
+palette = 1=$ghostty_palette_color_1
+palette = 2=$ghostty_palette_color_2
+palette = 3=$ghostty_palette_color_3
+palette = 4=$ghostty_palette_color_4
+palette = 5=$ghostty_palette_color_5
+palette = 6=$ghostty_palette_color_6
+palette = 7=$ghostty_palette_color_7
+palette = 8=$ghostty_palette_color_8
+palette = 9=$ghostty_palette_color_9
+palette = 10=$ghostty_palette_color_10
+palette = 11=$ghostty_palette_color_11
+palette = 12=$ghostty_palette_color_12
+palette = 13=$ghostty_palette_color_13
+palette = 14=$ghostty_palette_color_14
+palette = 15=$ghostty_palette_color_15
+palette = 16=$ghostty_palette_color_16
+palette = 17=$ghostty_palette_color_17
+palette = 18=$ghostty_palette_color_18
+palette = 19=$ghostty_palette_color_19
+palette = 20=$ghostty_palette_color_20
+palette = 21=$ghostty_palette_color_21
 
 # Foreground & background colors
-background = #{{ base00-hex }}
-foreground = #{{ base05-hex }}
-cursor-color = #{{ base05-hex }}
-selection-background = #{{ base02-hex }}
-selection-foreground = #{{ base05-hex }}
+background = $ghostty_palette_color_0
+foreground = $ghostty_palette_color_7
+cursor-color = $ghostty_palette_color_7
+selection-background = $ghostty_palette_color_8
+selection-foreground = $ghostty_palette_color_7
 
-# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+# Set macos-icon = custom-style in your main configuration file to enable theming of the app icon.
 EOF
 }
+
+_palette_value {
+    # Indirect expansion is not POSIX-compliant. Writing this as a switch-case avoids using eval and injection risks that
+    # comes with it.
+    case "$1" in
+        "0") echo $ghostty_palette_color_0
+            break
+            ;;
+        "1") echo $ghostty_palette_color_1
+            break
+            ;;
+        "2") echo $ghostty_palette_color_2
+            break
+            ;;
+        "3") echo $ghostty_palette_color_3
+            break
+            ;;
+        "4") echo $ghostty_palette_color_4
+            break
+            ;;
+        "5") echo $ghostty_palette_color_5
+            break
+            ;;
+        "6") echo $ghostty_palette_color_6
+            break
+            ;;
+        "7") echo $ghostty_palette_color_7
+            break
+            ;;
+        "8") echo $ghostty_palette_color_8
+            break
+            ;;
+        "9") echo $ghostty_palette_color_9
+            break
+            ;;
+        "10") echo $ghostty_palette_color_10
+            break
+            ;;
+        "11") echo $ghostty_palette_color_11
+            break
+            ;;
+        "12") echo $ghostty_palette_color_12
+            break
+            ;;
+        "13") echo $ghostty_palette_color_13
+            break
+            ;;
+        "14") echo $ghostty_palette_color_14
+            break
+            ;;
+        "15") echo $ghostty_palette_color_15
+            break
+            ;;
+        "16") echo $ghostty_palette_color_16
+            break
+            ;;
+        "17") echo $ghostty_palette_color_17
+            break
+            ;;
+        "18") echo $ghostty_palette_color_18
+            break
+            ;;
+        "19") echo $ghostty_palette_color_19
+            break
+            ;;
+        "20") echo $ghostty_palette_color_20
+            break
+            ;;
+        "21") echo $ghostty_palette_color_21
+            break
+            ;;
+    esac
+}
+
+
 
 OPTIND=1
 
@@ -83,11 +173,11 @@ screen_colors_arg=12 # Default screen color to Bright Blue
 while [[ -n "$1" ]]; do
     case "$1" in
         -g)
-            ghost_color_arg=$2
+            ghost_color_arg="$2"
             shift 2
             ;;
         -s)
-            screen_colors_arg=$2
+            screen_colors_arg="$2"
             shift 2
             ;;
         --)
@@ -107,7 +197,7 @@ while [[ -n "$1" ]]; do
 done
 
 screen_color_values=
-ghost_color_value=$(_extract_palette_value $ghost_color_arg)
+ghost_color_value=$(_palette_value $ghost_color_arg)
 
 _theme_file
 
@@ -121,18 +211,18 @@ fi
 screen_color_values=$(
     o=
     echo $screen_colors_arg | tr ',' "\n" | while read c; do
-        color_value=$(_extract_palette_value $c)
+        color_value=$(_palette_value $c)
         if [ -n "$color_value" ]; then
-            if [[ -n "$o" ]]; then
-                color_value=",${color_value}"
+            if [ -n "$o" ]; then
+                color_value=",$color_value"
             fi
-            o="${o}${color_value}"
-            echo $o
+            o="$o$color_value"
+            echo "$o"
         fi
     done | tail -n 1
 )
 
 if [ -n "$screen_color_values" ]; then
-    echo "# Extracted palette colors ${screen_colors_arg}:"
-    echo "macos-icon-screen-color = ${screen_color_values}"
+    echo "# Extracted palette colors $screen_colors_arg:"
+    echo "macos-icon-screen-color = $screen_color_values"
 fi

--- a/templates/ghostty-script-base24.mustache
+++ b/templates/ghostty-script-base24.mustache
@@ -82,7 +82,7 @@ cursor-color = $ghostty_palette_color_7
 selection-background = $ghostty_palette_color_8
 selection-foreground = $ghostty_palette_color_7
 
-# Set macos-icon = custom-style in your main configuration file to enable theming of the app icon.
+# Set \`macos-icon\` = custom-style in your main configuration file to enable theming of the app icon.
 EOF
 }
 
@@ -170,7 +170,7 @@ eval set -- "$OPTS"
 ghost_color_arg=15 # Default ghost color to Bright White
 screen_colors_arg=12 # Default screen color to Bright Blue
 
-while [[ -n "$1" ]]; do
+while [ -n "$1" ]; do
     case "$1" in
         -g)
             ghost_color_arg="$2"

--- a/templates/ghostty-script-base24.mustache
+++ b/templates/ghostty-script-base24.mustache
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 # vim: ft=sh
 
-_help {
+_help() {
     2>&1 cat <<EOF
 Generates a Ghostty theme file with macos-icon-ghost-color and macos-icon-screen-color directives
 based on an existing theme. This script is mainly designed to be used with tinted-theming/tinty.
@@ -43,7 +43,7 @@ ghostty_palette_color_19="#{{ base02-hex }}"
 ghostty_palette_color_20="#{{ base04-hex }}"
 ghostty_palette_color_21="#{{ base06-hex }}"
 
-_theme_file {
+_theme_file() {
 cat <<EOF
 # vim: ft=ghostty
 # {{ scheme-name }} theme for Ghostty
@@ -86,7 +86,7 @@ selection-foreground = $ghostty_palette_color_7
 EOF
 }
 
-_palette_value {
+_palette_value() {
     # Indirect expansion is not POSIX-compliant. Writing this as a switch-case avoids using eval and injection risks that
     # comes with it.
     case "$1" in

--- a/templates/ghostty-script-base24.mustache
+++ b/templates/ghostty-script-base24.mustache
@@ -1,0 +1,138 @@
+#!/usr/bin/env sh
+
+# ===================
+# ghostty-icon-tinter
+# ===================
+
+function _extract_palette_value {
+    # Note: return the last recurrence, in case there are multiple.
+    _theme_file | sed -nE 's/palette = '$1'=(#.*)/\1/p' \
+       | tail -n 1
+}
+
+function _help {
+    2>&1 cat <<EOF
+Generates a Ghostty theme file with macos-icon-ghost-color and macos-icon-screen-color directives
+based on an existing theme. This script is mainly designed to be used with tinted-theming/tinty.
+
+OPTIONS:
+
+    -g palette_index
+    	Use palette[palette_index] as macos-icon-ghost-color
+
+    -s palette_index|palette_indices
+
+        Use palette[palette_index] as macos-icon-screen-color. 
+        If you wish the screen color to be a gradient, specify a comma-separated list of 
+        indices e.g. -s 12,6,2
+EOF
+}
+
+function _theme_file {
+cat <<EOF
+# vim: ft=ghostty
+# {{ scheme-name }} theme for Ghostty
+# Scheme Author: {{ scheme-author }}
+# Scheme System: {{ scheme-system }}
+# Template Author: Tinted Terminal (https://github.com/tinted-theming/tinted-terminal)
+
+# Color palette
+palette = 0=#{{ base00-hex }}
+palette = 1=#{{ base08-hex }}
+palette = 2=#{{ base0B-hex }}
+palette = 3=#{{ base0A-hex }}
+palette = 4=#{{ base0D-hex }}
+palette = 5=#{{ base0E-hex }}
+palette = 6=#{{ base0C-hex }}
+palette = 7=#{{ base06-hex }}
+palette = 8=#{{ base02-hex }}
+palette = 9=#{{ base12-hex }}
+palette = 10=#{{ base14-hex }}
+palette = 11=#{{ base13-hex }}
+palette = 12=#{{ base16-hex }}
+palette = 13=#{{ base17-hex }}
+palette = 14=#{{ base15-hex }}
+palette = 15=#{{ base07-hex }}
+palette = 16=#{{ base09-hex }}
+palette = 17=#{{ base0F-hex }}
+palette = 18=#{{ base01-hex }}
+palette = 19=#{{ base02-hex }}
+palette = 20=#{{ base04-hex }}
+palette = 21=#{{ base06-hex }}
+
+# Foreground & background colors
+background = #{{ base00-hex }}
+foreground = #{{ base05-hex }}
+cursor-color = #{{ base05-hex }}
+selection-background = #{{ base02-hex }}
+selection-foreground = #{{ base05-hex }}
+
+# Set `macos-icon = custom-style` in your main configuration file to enable theming of the app icon.
+EOF
+}
+
+OPTIND=1
+
+OPTS=$(getopt g:s:h $*) || exit 2
+
+eval set -- "$OPTS"
+
+ghost_color_arg=15 # Default ghost color to Bright White
+screen_colors_arg=12 # Default screen color to Bright Blue
+
+while [[ -n "$1" ]]; do
+    case "$1" in
+        -g)
+            ghost_color_arg=$2
+            shift 2
+            ;;
+        -s)
+            screen_colors_arg=$2
+            shift 2
+            ;;
+        --)
+            shift
+            break
+            ;;
+        -h)
+            shift
+            _help
+            exit 0
+            ;;
+        -h)
+            _help
+            exit 1
+            ;;
+    esac
+done
+
+screen_color_values=
+ghost_color_value=$(_extract_palette_value $ghost_color_arg)
+
+_theme_file
+
+if [ -n "$ghost_color_value" ]; then
+    echo "# Extracted palette color $ghost_color_arg:"
+    echo "macos-icon-ghost-color = $ghost_color_value"
+fi
+
+# Parse comma-separated string in POSIX-compliant way
+# TODO: There has to be a better way to do this.
+screen_color_values=$(
+    o=
+    echo $screen_colors_arg | tr ',' "\n" | while read c; do
+        color_value=$(_extract_palette_value $c)
+        if [ -n "$color_value" ]; then
+            if [[ -n "$o" ]]; then
+                color_value=",${color_value}"
+            fi
+            o="${o}${color_value}"
+            echo $o
+        fi
+    done | tail -n 1
+)
+
+if [ -n "$screen_color_values" ]; then
+    echo "# Extracted palette colors ${screen_colors_arg}:"
+    echo "macos-icon-screen-color = ${screen_color_values}"
+fi


### PR DESCRIPTION
Ghostty allow users to customize the look of the app icon through configuration options that a theme can set. The ghost and the screen can be tinted separately:

![GgDz3crXIAAMGhP](https://github.com/user-attachments/assets/2891e329-82a5-4702-9fbf-1e1a14683045)
<p align=right>– <a href="https://x.com/flarup/status/1873770832230834362">X</a></p>

Today, the Ghostty themes customizes the ghost color to be the `Bright White` color, and the screen color to be the `Bright Blue` color, to replace the screen`s default blue tint. 

Ideally we can offer users a way to choose whichever color they like from the theme’s palette for the icon.

```toml

[[items]]

path = "https://github.com/tinted-theming/tinted-terminal"
name = "tinted-terminal"
themes-dir = "themes/ghostty-scripts"

# Use palette[15] for ghost color
# and palette[12], palette[6] as screen gradient:
hook = '''
sh %f -g 15 \
   -s 12,6 \
   >! ~/.config/ghostty/themes/tinted-theming
'''
supported-systems = ["base16", "base24"]
```

Trying my best to keep this script POSIX compliant.