### PR TITLE
Add support for windows terminal

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -53,6 +53,10 @@ README.md @tinted-theming/terminal
 /templates/termite-* @tinted-theming/termite-terminal
 /themes/termite/* @tinted-theming/termite-terminal
 
+# Windows Terminal
+/templates/windows-terminal-* @tinted-theming/windows-terminal
+/themes/windows-terminal/* @tinted-theming/windows-terminal
+
 # XFCE4
 /templates/xfce4-* @tinted-theming/xfce4-terminal
 /themes/xfce4/* @tinted-theming/xfce4-terminal

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -41,7 +41,7 @@ ghostty-base24:
 ghostty-script-base16:
   filename: themes/ghostty-scripts/{{ scheme-system }}-{{ scheme-slug }}.sh
   supported-systems: [base16]
-  
+
 ghostty-script-base24:
   filename: themes/ghostty-scripts/{{ scheme-system }}-{{ scheme-slug }}.sh
   supported-systems: [base24]
@@ -100,11 +100,11 @@ putty-base24:
 
 # Rio
 # ----------------------------------------------------------------------
-rio-base16-16: 
+rio-base16-16:
   filename: themes-16/rio/{{ scheme-system }}-{{ scheme-slug }}.toml
   supported-systems: [base16]
 
-rio-base24-16: 
+rio-base24-16:
   filename: themes-16/rio/{{ scheme-system }}-{{ scheme-slug }}.toml
   supported-systems: [base24]
 
@@ -116,6 +116,16 @@ termite-base16:
 
 termite-base24:
   filename: themes/termite/{{ scheme-system }}-{{ scheme-slug }}.config
+  supported-systems: [base24]
+
+# Windows Terminal
+# ----------------------------------------------------------------------
+windows-terminal-base16:
+  filename: themes/windows-terminal/{{ scheme-system }}-{{ scheme-slug }}.theme
+  supported-systems: [base16]
+
+windows-terminal-base24:
+  filename: themes/windows-terminal/{{ scheme-system }}-{{ scheme-slug }}.theme
   supported-systems: [base24]
 
 # xfce4

--- a/templates/windows-terminal-base16.mustache
+++ b/templates/windows-terminal-base16.mustache
@@ -1,0 +1,22 @@
+// Add custom color schemes to the "schemes" array
+{
+	"name": "{{scheme-name}}",
+	"foreground": "#{{base05-hex}}",
+	"background": "#{{base00-hex}}",
+	"black": "#{{base01-hex}}",
+	"blue": "#{{base0D-hex}}",
+	"brightBlack": "#{{base02-hex}}",
+	"brightBlue": "#{{base0D-hex}}",
+	"brightCyan": "#{{base0C-hex}}",
+	"brightGreen": "#{{base0B-hex}}",
+	"brightPurple": "#{{base0E-hex}}",
+	"brightRed": "#{{base08-hex}}",
+	"brightWhite": "#{{base07-hex}}",
+	"brightYellow": "#{{base0A-hex}}",
+	"cyan": "#{{base0C-hex}}",
+	"green": "#{{base0B-hex}}",
+	"purple": "#{{base0E-hex}}",
+	"red": "#{{base08-hex}}",
+	"white": "#{{base06-hex}}",
+	"yellow": "#{{base09-hex}}"
+},

--- a/templates/windows-terminal-base24.mustache
+++ b/templates/windows-terminal-base24.mustache
@@ -1,0 +1,22 @@
+// Add custom color schemes to the "schemes" array
+{
+	"name": "{{scheme-name}}",
+	"foreground": "#{{base05-hex}}",
+	"background": "#{{base00-hex}}",
+	"black": "#{{base01-hex}}",
+	"blue": "#{{base0D-hex}}",
+	"brightBlack": "#{{base02-hex}}",
+	"brightBlue": "#{{base16-hex}}",
+	"brightCyan": "#{{base15-hex}}",
+	"brightGreen": "#{{base14-hex}}",
+	"brightPurple": "#{{base17-hex}}",
+	"brightRed": "#{{base12-hex}}",
+	"brightWhite": "#{{base07-hex}}",
+	"brightYellow": "#{{base13-hex}}",
+	"cyan": "#{{base0C-hex}}",
+	"green": "#{{base0B-hex}}",
+	"purple": "#{{base0E-hex}}",
+	"red": "#{{base08-hex}}",
+	"white": "#{{base06-hex}}",
+	"yellow": "#{{base09-hex}}"
+},


### PR DESCRIPTION
This copies across the `.mustache` files from:

- https://github.com/tinted-theming/base16-windows-terminal
- https://github.com/tinted-theming/base24-windows-terminal

@FredHappyface I've added you as the maintainer for this section through the CODEOWNERS file

Addresses https://github.com/tinted-theming/tinted-terminal/issues/7