### PR TITLE
xfce4-terminal no longer uses terminalrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -645,7 +645,7 @@ Tinted Theming template for [xfce4 terminal emulator].
    themes-dir = "themes/xfce4"
    hook = """
    mkdir -p $XDG_CONFIG_HOME/xfce4/terminal/colorschemes
-   cat %f $XDG_CONFIG_HOME/xfce4/terminal/colorschemes/%n.theme
+   cat %f > $XDG_CONFIG_HOME/xfce4/terminal/colorschemes/%n.theme
    """
    supported-systems = ["base16", "base24"]
    ```

--- a/README.md
+++ b/README.md
@@ -636,38 +636,24 @@ Tinted Theming template for [xfce4 terminal emulator].
 
 ### Tinty
 
-1. Clone the tinted-terminal themes and symlink to Rio themes directory:
-
-   ```sh
-   git clone https://github.com/tinted-theming/tinted-terminal /path/to/tinted-terminal
-   mkdir -p ~/.local/share/xfce4/terminal
-   ln -s /path/to/tinted-terminal/xfce4 ~/.local/share/xfce4/terminal/colorschemes
-   ```
-
-2. Add the following to `~/.config/tinted-theming/tinty/config.toml`:
+1. Add the following to `~/.config/tinted-theming/tinty/config.toml`:
 
    ```toml
    [[items]]
-   path = "~/projects/tinted-theming/tinted-xfce4-terminal"
+   path = "https://github.com/tinted-theming/tinted-terminal"
    name = "tinted-xfce4-terminal"
    themes-dir = "themes/xfce4"
    hook = """
-   # Adapted from https://askubuntu.com/questions/676428/change-color-scheme-for-xfce4-terminal-manually#answer-676452
-   if [[ -e $HOME/.local/share/xfce4/terminal/colorschemes/%n.theme ]]
-   then
-     cd $HOME/.config/xfce4/terminal
-     # strip settings from any themes
-     grep -Fxvf <(cat $HOME/.local/share/xfce4/terminal/colorschemes/*.theme) terminalrc > .terminalrc.tmp
-     grep -v -e Name -e Scheme "$HOME/.local/share/xfce4/terminal/colorschemes/%n.theme" >> .terminalrc.tmp
-     cp terminalrc terminalrc.bak
-     mv .terminalrc.tmp terminalrc
-   fi
+   mkdir -p $XDG_CONFIG_HOME/xfce4/terminal/colorschemes
+   cat %f $XDG_CONFIG_HOME/xfce4/terminal/colorschemes/%n.theme
    """
    supported-systems = ["base16", "base24"]
    ```
 
-3. `tinty apply base16-ayu-dark` to change the theme to
+2. `tinty sync && tinty apply base16-ayu-dark` to change the theme to
    `base16-ayu-dark`
+
+3. The theme will be available under `Preferences > Colors > Presets`.
 
 For more information on Tinty setup or usage, have a look at the [Tinty]
 GitHub page.
@@ -676,8 +662,7 @@ GitHub page.
 
 Put the prebuilt `*.theme` files from `colorschemes/` into
 `~/.local/share/xfce4/terminal/colorschemes/` (create this directory if
-it does not exist), and the themes will be available under `Edit >
-Preferences... > Colors > Presets`
+it does not exist), and the themes will be available under `Preferences > Colors > Presets`.
 
 ```sh
 mkdir -p ~/.local/share/xfce4/terminal


### PR DESCRIPTION
According to the [upstream docs](https://docs.xfce.org/apps/xfce4-terminal/advanced), xfce4-terminal now uses xfconf as a backend for all settings. This PR removes the instructions to manage the now deprecated `terminalrc` file and instead, uses `%f` and `%n` to write the appropriate `.theme` file.

I tried to extend the hook to set the colorscheme via `/color-use-theme` but it didn't work and honestly, I don't know what that field is used for now. Here's what I tried before settling on telling the user to just set it manually via Preferences....

```
xfconf-query -c xfce4-terminal -p /color-use-theme -t string -s the-theme-name-without-the-dot-extension
```

FYI, we can see all the fields and their values with the following:

```
xfconf-query -c xfce4-terminal -l -v
```

I almost updated the manual section as well but backed away as I'm not entirely sure what exactly is being proposed. I tend to think the section could be simplified and made more clear. Seems like things would be fine if the user just threw the .theme files from this repo's `themes/xfce4` directory into their `$XDG_CONFIG_HOME/xfce4/terminal/colorschemes` directory before selecting via `Preferences...`
