### PR TITLE
feat: Reverse cursor colors

### DIFF
--- a/templates/wezterm-base16.mustache
+++ b/templates/wezterm-base16.mustache
@@ -4,9 +4,9 @@
 background = "#{{base00-hex}}"
 foreground = "#{{base05-hex}}"
 
-cursor_bg = "#{{base01-hex}}"
+cursor_bg = "#{{base05-hex}}"
 cursor_border = "#{{base05-hex}}"
-cursor_fg = "#{{base06-hex}}"
+cursor_fg = "#{{base00-hex}}"
 
 selection_bg = "#{{base05-hex}}"
 selection_fg = "#{{base00-hex}}"

--- a/themes/wezterm/base16-0x96f.toml
+++ b/themes/wezterm/base16-0x96f.toml
@@ -4,9 +4,9 @@
 background = "#262427"
 foreground = "#fcfcfc"
 
-cursor_bg = "#3b393c"
+cursor_bg = "#fcfcfc"
 cursor_border = "#fcfcfc"
-cursor_fg = "#eae9eb"
+cursor_fg = "#262427"
 
 selection_bg = "#fcfcfc"
 selection_fg = "#262427"

--- a/themes/wezterm/base16-3024.toml
+++ b/themes/wezterm/base16-3024.toml
@@ -4,9 +4,9 @@
 background = "#090300"
 foreground = "#a5a2a2"
 
-cursor_bg = "#3a3432"
+cursor_bg = "#a5a2a2"
 cursor_border = "#a5a2a2"
-cursor_fg = "#d6d5d4"
+cursor_fg = "#090300"
 
 selection_bg = "#a5a2a2"
 selection_fg = "#090300"

--- a/themes/wezterm/base16-apathy.toml
+++ b/themes/wezterm/base16-apathy.toml
@@ -4,9 +4,9 @@
 background = "#031a16"
 foreground = "#81b5ac"
 
-cursor_bg = "#0b342d"
+cursor_bg = "#81b5ac"
 cursor_border = "#81b5ac"
-cursor_fg = "#a7cec8"
+cursor_fg = "#031a16"
 
 selection_bg = "#81b5ac"
 selection_fg = "#031a16"

--- a/themes/wezterm/base16-apprentice.toml
+++ b/themes/wezterm/base16-apprentice.toml
@@ -4,9 +4,9 @@
 background = "#262626"
 foreground = "#5f5f87"
 
-cursor_bg = "#af5f5f"
+cursor_bg = "#5f5f87"
 cursor_border = "#5f5f87"
-cursor_fg = "#5f8787"
+cursor_fg = "#262626"
 
 selection_bg = "#5f5f87"
 selection_fg = "#262626"

--- a/themes/wezterm/base16-ashes.toml
+++ b/themes/wezterm/base16-ashes.toml
@@ -4,9 +4,9 @@
 background = "#1c2023"
 foreground = "#c7ccd1"
 
-cursor_bg = "#393f45"
+cursor_bg = "#c7ccd1"
 cursor_border = "#c7ccd1"
-cursor_fg = "#dfe2e5"
+cursor_fg = "#1c2023"
 
 selection_bg = "#c7ccd1"
 selection_fg = "#1c2023"

--- a/themes/wezterm/base16-atelier-cave-light.toml
+++ b/themes/wezterm/base16-atelier-cave-light.toml
@@ -4,9 +4,9 @@
 background = "#efecf4"
 foreground = "#585260"
 
-cursor_bg = "#e2dfe7"
+cursor_bg = "#585260"
 cursor_border = "#585260"
-cursor_fg = "#26232a"
+cursor_fg = "#efecf4"
 
 selection_bg = "#585260"
 selection_fg = "#efecf4"

--- a/themes/wezterm/base16-atelier-cave.toml
+++ b/themes/wezterm/base16-atelier-cave.toml
@@ -4,9 +4,9 @@
 background = "#19171c"
 foreground = "#8b8792"
 
-cursor_bg = "#26232a"
+cursor_bg = "#8b8792"
 cursor_border = "#8b8792"
-cursor_fg = "#e2dfe7"
+cursor_fg = "#19171c"
 
 selection_bg = "#8b8792"
 selection_fg = "#19171c"

--- a/themes/wezterm/base16-atelier-dune-light.toml
+++ b/themes/wezterm/base16-atelier-dune-light.toml
@@ -4,9 +4,9 @@
 background = "#fefbec"
 foreground = "#6e6b5e"
 
-cursor_bg = "#e8e4cf"
+cursor_bg = "#6e6b5e"
 cursor_border = "#6e6b5e"
-cursor_fg = "#292824"
+cursor_fg = "#fefbec"
 
 selection_bg = "#6e6b5e"
 selection_fg = "#fefbec"

--- a/themes/wezterm/base16-atelier-dune.toml
+++ b/themes/wezterm/base16-atelier-dune.toml
@@ -4,9 +4,9 @@
 background = "#20201d"
 foreground = "#a6a28c"
 
-cursor_bg = "#292824"
+cursor_bg = "#a6a28c"
 cursor_border = "#a6a28c"
-cursor_fg = "#e8e4cf"
+cursor_fg = "#20201d"
 
 selection_bg = "#a6a28c"
 selection_fg = "#20201d"

--- a/themes/wezterm/base16-atelier-estuary-light.toml
+++ b/themes/wezterm/base16-atelier-estuary-light.toml
@@ -4,9 +4,9 @@
 background = "#f4f3ec"
 foreground = "#5f5e4e"
 
-cursor_bg = "#e7e6df"
+cursor_bg = "#5f5e4e"
 cursor_border = "#5f5e4e"
-cursor_fg = "#302f27"
+cursor_fg = "#f4f3ec"
 
 selection_bg = "#5f5e4e"
 selection_fg = "#f4f3ec"

--- a/themes/wezterm/base16-atelier-estuary.toml
+++ b/themes/wezterm/base16-atelier-estuary.toml
@@ -4,9 +4,9 @@
 background = "#22221b"
 foreground = "#929181"
 
-cursor_bg = "#302f27"
+cursor_bg = "#929181"
 cursor_border = "#929181"
-cursor_fg = "#e7e6df"
+cursor_fg = "#22221b"
 
 selection_bg = "#929181"
 selection_fg = "#22221b"

--- a/themes/wezterm/base16-atelier-forest-light.toml
+++ b/themes/wezterm/base16-atelier-forest-light.toml
@@ -4,9 +4,9 @@
 background = "#f1efee"
 foreground = "#68615e"
 
-cursor_bg = "#e6e2e0"
+cursor_bg = "#68615e"
 cursor_border = "#68615e"
-cursor_fg = "#2c2421"
+cursor_fg = "#f1efee"
 
 selection_bg = "#68615e"
 selection_fg = "#f1efee"

--- a/themes/wezterm/base16-atelier-forest.toml
+++ b/themes/wezterm/base16-atelier-forest.toml
@@ -4,9 +4,9 @@
 background = "#1b1918"
 foreground = "#a8a19f"
 
-cursor_bg = "#2c2421"
+cursor_bg = "#a8a19f"
 cursor_border = "#a8a19f"
-cursor_fg = "#e6e2e0"
+cursor_fg = "#1b1918"
 
 selection_bg = "#a8a19f"
 selection_fg = "#1b1918"

--- a/themes/wezterm/base16-atelier-heath-light.toml
+++ b/themes/wezterm/base16-atelier-heath-light.toml
@@ -4,9 +4,9 @@
 background = "#f7f3f7"
 foreground = "#695d69"
 
-cursor_bg = "#d8cad8"
+cursor_bg = "#695d69"
 cursor_border = "#695d69"
-cursor_fg = "#292329"
+cursor_fg = "#f7f3f7"
 
 selection_bg = "#695d69"
 selection_fg = "#f7f3f7"

--- a/themes/wezterm/base16-atelier-heath.toml
+++ b/themes/wezterm/base16-atelier-heath.toml
@@ -4,9 +4,9 @@
 background = "#1b181b"
 foreground = "#ab9bab"
 
-cursor_bg = "#292329"
+cursor_bg = "#ab9bab"
 cursor_border = "#ab9bab"
-cursor_fg = "#d8cad8"
+cursor_fg = "#1b181b"
 
 selection_bg = "#ab9bab"
 selection_fg = "#1b181b"

--- a/themes/wezterm/base16-atelier-lakeside-light.toml
+++ b/themes/wezterm/base16-atelier-lakeside-light.toml
@@ -4,9 +4,9 @@
 background = "#ebf8ff"
 foreground = "#516d7b"
 
-cursor_bg = "#c1e4f6"
+cursor_bg = "#516d7b"
 cursor_border = "#516d7b"
-cursor_fg = "#1f292e"
+cursor_fg = "#ebf8ff"
 
 selection_bg = "#516d7b"
 selection_fg = "#ebf8ff"

--- a/themes/wezterm/base16-atelier-lakeside.toml
+++ b/themes/wezterm/base16-atelier-lakeside.toml
@@ -4,9 +4,9 @@
 background = "#161b1d"
 foreground = "#7ea2b4"
 
-cursor_bg = "#1f292e"
+cursor_bg = "#7ea2b4"
 cursor_border = "#7ea2b4"
-cursor_fg = "#c1e4f6"
+cursor_fg = "#161b1d"
 
 selection_bg = "#7ea2b4"
 selection_fg = "#161b1d"

--- a/themes/wezterm/base16-atelier-plateau-light.toml
+++ b/themes/wezterm/base16-atelier-plateau-light.toml
@@ -4,9 +4,9 @@
 background = "#f4ecec"
 foreground = "#585050"
 
-cursor_bg = "#e7dfdf"
+cursor_bg = "#585050"
 cursor_border = "#585050"
-cursor_fg = "#292424"
+cursor_fg = "#f4ecec"
 
 selection_bg = "#585050"
 selection_fg = "#f4ecec"

--- a/themes/wezterm/base16-atelier-plateau.toml
+++ b/themes/wezterm/base16-atelier-plateau.toml
@@ -4,9 +4,9 @@
 background = "#1b1818"
 foreground = "#8a8585"
 
-cursor_bg = "#292424"
+cursor_bg = "#8a8585"
 cursor_border = "#8a8585"
-cursor_fg = "#e7dfdf"
+cursor_fg = "#1b1818"
 
 selection_bg = "#8a8585"
 selection_fg = "#1b1818"

--- a/themes/wezterm/base16-atelier-savanna-light.toml
+++ b/themes/wezterm/base16-atelier-savanna-light.toml
@@ -4,9 +4,9 @@
 background = "#ecf4ee"
 foreground = "#526057"
 
-cursor_bg = "#dfe7e2"
+cursor_bg = "#526057"
 cursor_border = "#526057"
-cursor_fg = "#232a25"
+cursor_fg = "#ecf4ee"
 
 selection_bg = "#526057"
 selection_fg = "#ecf4ee"

--- a/themes/wezterm/base16-atelier-savanna.toml
+++ b/themes/wezterm/base16-atelier-savanna.toml
@@ -4,9 +4,9 @@
 background = "#171c19"
 foreground = "#87928a"
 
-cursor_bg = "#232a25"
+cursor_bg = "#87928a"
 cursor_border = "#87928a"
-cursor_fg = "#dfe7e2"
+cursor_fg = "#171c19"
 
 selection_bg = "#87928a"
 selection_fg = "#171c19"

--- a/themes/wezterm/base16-atelier-seaside-light.toml
+++ b/themes/wezterm/base16-atelier-seaside-light.toml
@@ -4,9 +4,9 @@
 background = "#f4fbf4"
 foreground = "#5e6e5e"
 
-cursor_bg = "#cfe8cf"
+cursor_bg = "#5e6e5e"
 cursor_border = "#5e6e5e"
-cursor_fg = "#242924"
+cursor_fg = "#f4fbf4"
 
 selection_bg = "#5e6e5e"
 selection_fg = "#f4fbf4"

--- a/themes/wezterm/base16-atelier-seaside.toml
+++ b/themes/wezterm/base16-atelier-seaside.toml
@@ -4,9 +4,9 @@
 background = "#131513"
 foreground = "#8ca68c"
 
-cursor_bg = "#242924"
+cursor_bg = "#8ca68c"
 cursor_border = "#8ca68c"
-cursor_fg = "#cfe8cf"
+cursor_fg = "#131513"
 
 selection_bg = "#8ca68c"
 selection_fg = "#131513"

--- a/themes/wezterm/base16-atelier-sulphurpool-light.toml
+++ b/themes/wezterm/base16-atelier-sulphurpool-light.toml
@@ -4,9 +4,9 @@
 background = "#f5f7ff"
 foreground = "#5e6687"
 
-cursor_bg = "#dfe2f1"
+cursor_bg = "#5e6687"
 cursor_border = "#5e6687"
-cursor_fg = "#293256"
+cursor_fg = "#f5f7ff"
 
 selection_bg = "#5e6687"
 selection_fg = "#f5f7ff"

--- a/themes/wezterm/base16-atelier-sulphurpool.toml
+++ b/themes/wezterm/base16-atelier-sulphurpool.toml
@@ -4,9 +4,9 @@
 background = "#202746"
 foreground = "#979db4"
 
-cursor_bg = "#293256"
+cursor_bg = "#979db4"
 cursor_border = "#979db4"
-cursor_fg = "#dfe2f1"
+cursor_fg = "#202746"
 
 selection_bg = "#979db4"
 selection_fg = "#202746"

--- a/themes/wezterm/base16-atlas.toml
+++ b/themes/wezterm/base16-atlas.toml
@@ -4,9 +4,9 @@
 background = "#002635"
 foreground = "#a1a19a"
 
-cursor_bg = "#00384d"
+cursor_bg = "#a1a19a"
 cursor_border = "#a1a19a"
-cursor_fg = "#e6e6dc"
+cursor_fg = "#002635"
 
 selection_bg = "#a1a19a"
 selection_fg = "#002635"

--- a/themes/wezterm/base16-ayu-dark.toml
+++ b/themes/wezterm/base16-ayu-dark.toml
@@ -4,9 +4,9 @@
 background = "#0f1419"
 foreground = "#e6e1cf"
 
-cursor_bg = "#131721"
+cursor_bg = "#e6e1cf"
 cursor_border = "#e6e1cf"
-cursor_fg = "#e6e1cf"
+cursor_fg = "#0f1419"
 
 selection_bg = "#e6e1cf"
 selection_fg = "#0f1419"

--- a/themes/wezterm/base16-ayu-light.toml
+++ b/themes/wezterm/base16-ayu-light.toml
@@ -4,9 +4,9 @@
 background = "#fafafa"
 foreground = "#5c6773"
 
-cursor_bg = "#f3f4f5"
+cursor_bg = "#5c6773"
 cursor_border = "#5c6773"
-cursor_fg = "#242936"
+cursor_fg = "#fafafa"
 
 selection_bg = "#5c6773"
 selection_fg = "#fafafa"

--- a/themes/wezterm/base16-ayu-mirage.toml
+++ b/themes/wezterm/base16-ayu-mirage.toml
@@ -4,9 +4,9 @@
 background = "#171b24"
 foreground = "#cccac2"
 
-cursor_bg = "#1f2430"
+cursor_bg = "#cccac2"
 cursor_border = "#cccac2"
-cursor_fg = "#d9d7ce"
+cursor_fg = "#171b24"
 
 selection_bg = "#cccac2"
 selection_fg = "#171b24"

--- a/themes/wezterm/base16-aztec.toml
+++ b/themes/wezterm/base16-aztec.toml
@@ -4,9 +4,9 @@
 background = "#101600"
 foreground = "#ffda51"
 
-cursor_bg = "#1a1e01"
+cursor_bg = "#ffda51"
 cursor_border = "#ffda51"
-cursor_fg = "#ffe178"
+cursor_fg = "#101600"
 
 selection_bg = "#ffda51"
 selection_fg = "#101600"

--- a/themes/wezterm/base16-bespin.toml
+++ b/themes/wezterm/base16-bespin.toml
@@ -4,9 +4,9 @@
 background = "#28211c"
 foreground = "#8a8986"
 
-cursor_bg = "#36312e"
+cursor_bg = "#8a8986"
 cursor_border = "#8a8986"
-cursor_fg = "#9d9b97"
+cursor_fg = "#28211c"
 
 selection_bg = "#8a8986"
 selection_fg = "#28211c"

--- a/themes/wezterm/base16-black-metal-bathory.toml
+++ b/themes/wezterm/base16-black-metal-bathory.toml
@@ -4,9 +4,9 @@
 background = "#000000"
 foreground = "#c1c1c1"
 
-cursor_bg = "#121212"
+cursor_bg = "#c1c1c1"
 cursor_border = "#c1c1c1"
-cursor_fg = "#999999"
+cursor_fg = "#000000"
 
 selection_bg = "#c1c1c1"
 selection_fg = "#000000"

--- a/themes/wezterm/base16-black-metal-burzum.toml
+++ b/themes/wezterm/base16-black-metal-burzum.toml
@@ -4,9 +4,9 @@
 background = "#000000"
 foreground = "#c1c1c1"
 
-cursor_bg = "#121212"
+cursor_bg = "#c1c1c1"
 cursor_border = "#c1c1c1"
-cursor_fg = "#999999"
+cursor_fg = "#000000"
 
 selection_bg = "#c1c1c1"
 selection_fg = "#000000"

--- a/themes/wezterm/base16-black-metal-dark-funeral.toml
+++ b/themes/wezterm/base16-black-metal-dark-funeral.toml
@@ -4,9 +4,9 @@
 background = "#000000"
 foreground = "#c1c1c1"
 
-cursor_bg = "#121212"
+cursor_bg = "#c1c1c1"
 cursor_border = "#c1c1c1"
-cursor_fg = "#999999"
+cursor_fg = "#000000"
 
 selection_bg = "#c1c1c1"
 selection_fg = "#000000"

--- a/themes/wezterm/base16-black-metal-gorgoroth.toml
+++ b/themes/wezterm/base16-black-metal-gorgoroth.toml
@@ -4,9 +4,9 @@
 background = "#000000"
 foreground = "#c1c1c1"
 
-cursor_bg = "#121212"
+cursor_bg = "#c1c1c1"
 cursor_border = "#c1c1c1"
-cursor_fg = "#999999"
+cursor_fg = "#000000"
 
 selection_bg = "#c1c1c1"
 selection_fg = "#000000"

--- a/themes/wezterm/base16-black-metal-immortal.toml
+++ b/themes/wezterm/base16-black-metal-immortal.toml
@@ -4,9 +4,9 @@
 background = "#000000"
 foreground = "#c1c1c1"
 
-cursor_bg = "#121212"
+cursor_bg = "#c1c1c1"
 cursor_border = "#c1c1c1"
-cursor_fg = "#999999"
+cursor_fg = "#000000"
 
 selection_bg = "#c1c1c1"
 selection_fg = "#000000"

--- a/themes/wezterm/base16-black-metal-khold.toml
+++ b/themes/wezterm/base16-black-metal-khold.toml
@@ -4,9 +4,9 @@
 background = "#000000"
 foreground = "#c1c1c1"
 
-cursor_bg = "#121212"
+cursor_bg = "#c1c1c1"
 cursor_border = "#c1c1c1"
-cursor_fg = "#999999"
+cursor_fg = "#000000"
 
 selection_bg = "#c1c1c1"
 selection_fg = "#000000"

--- a/themes/wezterm/base16-black-metal-marduk.toml
+++ b/themes/wezterm/base16-black-metal-marduk.toml
@@ -4,9 +4,9 @@
 background = "#000000"
 foreground = "#c1c1c1"
 
-cursor_bg = "#121212"
+cursor_bg = "#c1c1c1"
 cursor_border = "#c1c1c1"
-cursor_fg = "#999999"
+cursor_fg = "#000000"
 
 selection_bg = "#c1c1c1"
 selection_fg = "#000000"

--- a/themes/wezterm/base16-black-metal-mayhem.toml
+++ b/themes/wezterm/base16-black-metal-mayhem.toml
@@ -4,9 +4,9 @@
 background = "#000000"
 foreground = "#c1c1c1"
 
-cursor_bg = "#121212"
+cursor_bg = "#c1c1c1"
 cursor_border = "#c1c1c1"
-cursor_fg = "#999999"
+cursor_fg = "#000000"
 
 selection_bg = "#c1c1c1"
 selection_fg = "#000000"

--- a/themes/wezterm/base16-black-metal-nile.toml
+++ b/themes/wezterm/base16-black-metal-nile.toml
@@ -4,9 +4,9 @@
 background = "#000000"
 foreground = "#c1c1c1"
 
-cursor_bg = "#121212"
+cursor_bg = "#c1c1c1"
 cursor_border = "#c1c1c1"
-cursor_fg = "#999999"
+cursor_fg = "#000000"
 
 selection_bg = "#c1c1c1"
 selection_fg = "#000000"

--- a/themes/wezterm/base16-black-metal-venom.toml
+++ b/themes/wezterm/base16-black-metal-venom.toml
@@ -4,9 +4,9 @@
 background = "#000000"
 foreground = "#c1c1c1"
 
-cursor_bg = "#121212"
+cursor_bg = "#c1c1c1"
 cursor_border = "#c1c1c1"
-cursor_fg = "#999999"
+cursor_fg = "#000000"
 
 selection_bg = "#c1c1c1"
 selection_fg = "#000000"

--- a/themes/wezterm/base16-black-metal.toml
+++ b/themes/wezterm/base16-black-metal.toml
@@ -4,9 +4,9 @@
 background = "#000000"
 foreground = "#c1c1c1"
 
-cursor_bg = "#121212"
+cursor_bg = "#c1c1c1"
 cursor_border = "#c1c1c1"
-cursor_fg = "#999999"
+cursor_fg = "#000000"
 
 selection_bg = "#c1c1c1"
 selection_fg = "#000000"

--- a/themes/wezterm/base16-blueforest.toml
+++ b/themes/wezterm/base16-blueforest.toml
@@ -4,9 +4,9 @@
 background = "#141f2e"
 foreground = "#ffcc33"
 
-cursor_bg = "#1e5c1e"
+cursor_bg = "#ffcc33"
 cursor_border = "#ffcc33"
-cursor_fg = "#91ccff"
+cursor_fg = "#141f2e"
 
 selection_bg = "#ffcc33"
 selection_fg = "#141f2e"

--- a/themes/wezterm/base16-blueish.toml
+++ b/themes/wezterm/base16-blueish.toml
@@ -4,9 +4,9 @@
 background = "#182430"
 foreground = "#c8e1f8"
 
-cursor_bg = "#243c54"
+cursor_bg = "#c8e1f8"
 cursor_border = "#c8e1f8"
-cursor_fg = "#ddeaf6"
+cursor_fg = "#182430"
 
 selection_bg = "#c8e1f8"
 selection_fg = "#182430"

--- a/themes/wezterm/base16-brewer.toml
+++ b/themes/wezterm/base16-brewer.toml
@@ -4,9 +4,9 @@
 background = "#0c0d0e"
 foreground = "#b7b8b9"
 
-cursor_bg = "#2e2f30"
+cursor_bg = "#b7b8b9"
 cursor_border = "#b7b8b9"
-cursor_fg = "#dadbdc"
+cursor_fg = "#0c0d0e"
 
 selection_bg = "#b7b8b9"
 selection_fg = "#0c0d0e"

--- a/themes/wezterm/base16-bright.toml
+++ b/themes/wezterm/base16-bright.toml
@@ -4,9 +4,9 @@
 background = "#000000"
 foreground = "#e0e0e0"
 
-cursor_bg = "#303030"
+cursor_bg = "#e0e0e0"
 cursor_border = "#e0e0e0"
-cursor_fg = "#f5f5f5"
+cursor_fg = "#000000"
 
 selection_bg = "#e0e0e0"
 selection_fg = "#000000"

--- a/themes/wezterm/base16-brogrammer.toml
+++ b/themes/wezterm/base16-brogrammer.toml
@@ -4,9 +4,9 @@
 background = "#1f1f1f"
 foreground = "#4e5ab7"
 
-cursor_bg = "#f81118"
+cursor_bg = "#4e5ab7"
 cursor_border = "#4e5ab7"
-cursor_fg = "#1081d6"
+cursor_fg = "#1f1f1f"
 
 selection_bg = "#4e5ab7"
 selection_fg = "#1f1f1f"

--- a/themes/wezterm/base16-brushtrees-dark.toml
+++ b/themes/wezterm/base16-brushtrees-dark.toml
@@ -4,9 +4,9 @@
 background = "#485867"
 foreground = "#b0c5c8"
 
-cursor_bg = "#5a6d7a"
+cursor_bg = "#b0c5c8"
 cursor_border = "#b0c5c8"
-cursor_fg = "#c9dbdc"
+cursor_fg = "#485867"
 
 selection_bg = "#b0c5c8"
 selection_fg = "#485867"

--- a/themes/wezterm/base16-brushtrees.toml
+++ b/themes/wezterm/base16-brushtrees.toml
@@ -4,9 +4,9 @@
 background = "#e3efef"
 foreground = "#6d828e"
 
-cursor_bg = "#c9dbdc"
+cursor_bg = "#6d828e"
 cursor_border = "#6d828e"
-cursor_fg = "#5a6d7a"
+cursor_fg = "#e3efef"
 
 selection_bg = "#6d828e"
 selection_fg = "#e3efef"

--- a/themes/wezterm/base16-caroline.toml
+++ b/themes/wezterm/base16-caroline.toml
@@ -4,9 +4,9 @@
 background = "#1c1213"
 foreground = "#a87569"
 
-cursor_bg = "#3a2425"
+cursor_bg = "#a87569"
 cursor_border = "#a87569"
-cursor_fg = "#c58d7b"
+cursor_fg = "#1c1213"
 
 selection_bg = "#a87569"
 selection_fg = "#1c1213"

--- a/themes/wezterm/base16-catppuccin-frappe.toml
+++ b/themes/wezterm/base16-catppuccin-frappe.toml
@@ -4,9 +4,9 @@
 background = "#303446"
 foreground = "#c6d0f5"
 
-cursor_bg = "#292c3c"
+cursor_bg = "#c6d0f5"
 cursor_border = "#c6d0f5"
-cursor_fg = "#f2d5cf"
+cursor_fg = "#303446"
 
 selection_bg = "#c6d0f5"
 selection_fg = "#303446"

--- a/themes/wezterm/base16-catppuccin-latte.toml
+++ b/themes/wezterm/base16-catppuccin-latte.toml
@@ -4,9 +4,9 @@
 background = "#eff1f5"
 foreground = "#4c4f69"
 
-cursor_bg = "#e6e9ef"
+cursor_bg = "#4c4f69"
 cursor_border = "#4c4f69"
-cursor_fg = "#dc8a78"
+cursor_fg = "#eff1f5"
 
 selection_bg = "#4c4f69"
 selection_fg = "#eff1f5"

--- a/themes/wezterm/base16-catppuccin-macchiato.toml
+++ b/themes/wezterm/base16-catppuccin-macchiato.toml
@@ -4,9 +4,9 @@
 background = "#24273a"
 foreground = "#cad3f5"
 
-cursor_bg = "#1e2030"
+cursor_bg = "#cad3f5"
 cursor_border = "#cad3f5"
-cursor_fg = "#f4dbd6"
+cursor_fg = "#24273a"
 
 selection_bg = "#cad3f5"
 selection_fg = "#24273a"

--- a/themes/wezterm/base16-catppuccin-mocha.toml
+++ b/themes/wezterm/base16-catppuccin-mocha.toml
@@ -4,9 +4,9 @@
 background = "#1e1e2e"
 foreground = "#cdd6f4"
 
-cursor_bg = "#181825"
+cursor_bg = "#cdd6f4"
 cursor_border = "#cdd6f4"
-cursor_fg = "#f5e0dc"
+cursor_fg = "#1e1e2e"
 
 selection_bg = "#cdd6f4"
 selection_fg = "#1e1e2e"

--- a/themes/wezterm/base16-chalk.toml
+++ b/themes/wezterm/base16-chalk.toml
@@ -4,9 +4,9 @@
 background = "#151515"
 foreground = "#d0d0d0"
 
-cursor_bg = "#202020"
+cursor_bg = "#d0d0d0"
 cursor_border = "#d0d0d0"
-cursor_fg = "#e0e0e0"
+cursor_fg = "#151515"
 
 selection_bg = "#d0d0d0"
 selection_fg = "#151515"

--- a/themes/wezterm/base16-chicago-day.toml
+++ b/themes/wezterm/base16-chicago-day.toml
@@ -4,9 +4,9 @@
 background = "#e8f0ea"
 foreground = "#364c40"
 
-cursor_bg = "#d1e0d7"
+cursor_bg = "#364c40"
 cursor_border = "#364c40"
-cursor_fg = "#2a3b32"
+cursor_fg = "#e8f0ea"
 
 selection_bg = "#364c40"
 selection_fg = "#e8f0ea"

--- a/themes/wezterm/base16-chicago-night.toml
+++ b/themes/wezterm/base16-chicago-night.toml
@@ -4,9 +4,9 @@
 background = "#1e2a24"
 foreground = "#a7b8af"
 
-cursor_bg = "#2a3b32"
+cursor_bg = "#a7b8af"
 cursor_border = "#a7b8af"
-cursor_fg = "#c1cdc7"
+cursor_fg = "#1e2a24"
 
 selection_bg = "#a7b8af"
 selection_fg = "#1e2a24"

--- a/themes/wezterm/base16-circus.toml
+++ b/themes/wezterm/base16-circus.toml
@@ -4,9 +4,9 @@
 background = "#191919"
 foreground = "#a7a7a7"
 
-cursor_bg = "#202020"
+cursor_bg = "#a7a7a7"
 cursor_border = "#a7a7a7"
-cursor_fg = "#808080"
+cursor_fg = "#191919"
 
 selection_bg = "#a7a7a7"
 selection_fg = "#191919"

--- a/themes/wezterm/base16-classic-dark.toml
+++ b/themes/wezterm/base16-classic-dark.toml
@@ -4,9 +4,9 @@
 background = "#151515"
 foreground = "#d0d0d0"
 
-cursor_bg = "#202020"
+cursor_bg = "#d0d0d0"
 cursor_border = "#d0d0d0"
-cursor_fg = "#e0e0e0"
+cursor_fg = "#151515"
 
 selection_bg = "#d0d0d0"
 selection_fg = "#151515"

--- a/themes/wezterm/base16-classic-light.toml
+++ b/themes/wezterm/base16-classic-light.toml
@@ -4,9 +4,9 @@
 background = "#f5f5f5"
 foreground = "#303030"
 
-cursor_bg = "#e0e0e0"
+cursor_bg = "#303030"
 cursor_border = "#303030"
-cursor_fg = "#202020"
+cursor_fg = "#f5f5f5"
 
 selection_bg = "#303030"
 selection_fg = "#f5f5f5"

--- a/themes/wezterm/base16-codeschool.toml
+++ b/themes/wezterm/base16-codeschool.toml
@@ -4,9 +4,9 @@
 background = "#232c31"
 foreground = "#9ea7a6"
 
-cursor_bg = "#1c3657"
+cursor_bg = "#9ea7a6"
 cursor_border = "#9ea7a6"
-cursor_fg = "#a7cfa3"
+cursor_fg = "#232c31"
 
 selection_bg = "#9ea7a6"
 selection_fg = "#232c31"

--- a/themes/wezterm/base16-colors.toml
+++ b/themes/wezterm/base16-colors.toml
@@ -4,9 +4,9 @@
 background = "#111111"
 foreground = "#bbbbbb"
 
-cursor_bg = "#333333"
+cursor_bg = "#bbbbbb"
 cursor_border = "#bbbbbb"
-cursor_fg = "#dddddd"
+cursor_fg = "#111111"
 
 selection_bg = "#bbbbbb"
 selection_fg = "#111111"

--- a/themes/wezterm/base16-cupcake.toml
+++ b/themes/wezterm/base16-cupcake.toml
@@ -4,9 +4,9 @@
 background = "#fbf1f2"
 foreground = "#8b8198"
 
-cursor_bg = "#f2f1f4"
+cursor_bg = "#8b8198"
 cursor_border = "#8b8198"
-cursor_fg = "#72677e"
+cursor_fg = "#fbf1f2"
 
 selection_bg = "#8b8198"
 selection_fg = "#fbf1f2"

--- a/themes/wezterm/base16-cupertino.toml
+++ b/themes/wezterm/base16-cupertino.toml
@@ -4,9 +4,9 @@
 background = "#ffffff"
 foreground = "#404040"
 
-cursor_bg = "#c0c0c0"
+cursor_bg = "#404040"
 cursor_border = "#404040"
-cursor_fg = "#404040"
+cursor_fg = "#ffffff"
 
 selection_bg = "#404040"
 selection_fg = "#ffffff"

--- a/themes/wezterm/base16-da-one-black.toml
+++ b/themes/wezterm/base16-da-one-black.toml
@@ -4,9 +4,9 @@
 background = "#000000"
 foreground = "#ffffff"
 
-cursor_bg = "#282828"
+cursor_bg = "#ffffff"
 cursor_border = "#ffffff"
-cursor_fg = "#ffffff"
+cursor_fg = "#000000"
 
 selection_bg = "#ffffff"
 selection_fg = "#000000"

--- a/themes/wezterm/base16-da-one-gray.toml
+++ b/themes/wezterm/base16-da-one-gray.toml
@@ -4,9 +4,9 @@
 background = "#181818"
 foreground = "#ffffff"
 
-cursor_bg = "#282828"
+cursor_bg = "#ffffff"
 cursor_border = "#ffffff"
-cursor_fg = "#ffffff"
+cursor_fg = "#181818"
 
 selection_bg = "#ffffff"
 selection_fg = "#181818"

--- a/themes/wezterm/base16-da-one-ocean.toml
+++ b/themes/wezterm/base16-da-one-ocean.toml
@@ -4,9 +4,9 @@
 background = "#171726"
 foreground = "#ffffff"
 
-cursor_bg = "#22273d"
+cursor_bg = "#ffffff"
 cursor_border = "#ffffff"
-cursor_fg = "#ffffff"
+cursor_fg = "#171726"
 
 selection_bg = "#ffffff"
 selection_fg = "#171726"

--- a/themes/wezterm/base16-da-one-paper.toml
+++ b/themes/wezterm/base16-da-one-paper.toml
@@ -4,9 +4,9 @@
 background = "#faf0dc"
 foreground = "#181818"
 
-cursor_bg = "#c8c8c8"
+cursor_bg = "#181818"
 cursor_border = "#181818"
-cursor_fg = "#000000"
+cursor_fg = "#faf0dc"
 
 selection_bg = "#181818"
 selection_fg = "#faf0dc"

--- a/themes/wezterm/base16-da-one-sea.toml
+++ b/themes/wezterm/base16-da-one-sea.toml
@@ -4,9 +4,9 @@
 background = "#22273d"
 foreground = "#ffffff"
 
-cursor_bg = "#374059"
+cursor_bg = "#ffffff"
 cursor_border = "#ffffff"
-cursor_fg = "#ffffff"
+cursor_fg = "#22273d"
 
 selection_bg = "#ffffff"
 selection_fg = "#22273d"

--- a/themes/wezterm/base16-da-one-white.toml
+++ b/themes/wezterm/base16-da-one-white.toml
@@ -4,9 +4,9 @@
 background = "#ffffff"
 foreground = "#181818"
 
-cursor_bg = "#c8c8c8"
+cursor_bg = "#181818"
 cursor_border = "#181818"
-cursor_fg = "#000000"
+cursor_fg = "#ffffff"
 
 selection_bg = "#181818"
 selection_fg = "#ffffff"

--- a/themes/wezterm/base16-danqing-light.toml
+++ b/themes/wezterm/base16-danqing-light.toml
@@ -4,9 +4,9 @@
 background = "#fcfefd"
 foreground = "#5a605d"
 
-cursor_bg = "#ecf6f2"
+cursor_bg = "#5a605d"
 cursor_border = "#5a605d"
-cursor_fg = "#434846"
+cursor_fg = "#fcfefd"
 
 selection_bg = "#5a605d"
 selection_fg = "#fcfefd"

--- a/themes/wezterm/base16-danqing.toml
+++ b/themes/wezterm/base16-danqing.toml
@@ -4,9 +4,9 @@
 background = "#2d302f"
 foreground = "#e0f0ef"
 
-cursor_bg = "#434846"
+cursor_bg = "#e0f0ef"
 cursor_border = "#e0f0ef"
-cursor_fg = "#ecf6f2"
+cursor_fg = "#2d302f"
 
 selection_bg = "#e0f0ef"
 selection_fg = "#2d302f"

--- a/themes/wezterm/base16-darcula.toml
+++ b/themes/wezterm/base16-darcula.toml
@@ -4,9 +4,9 @@
 background = "#2b2b2b"
 foreground = "#a9b7c6"
 
-cursor_bg = "#323232"
+cursor_bg = "#a9b7c6"
 cursor_border = "#a9b7c6"
-cursor_fg = "#ffc66d"
+cursor_fg = "#2b2b2b"
 
 selection_bg = "#a9b7c6"
 selection_fg = "#2b2b2b"

--- a/themes/wezterm/base16-darkmoss.toml
+++ b/themes/wezterm/base16-darkmoss.toml
@@ -4,9 +4,9 @@
 background = "#171e1f"
 foreground = "#c7c7a5"
 
-cursor_bg = "#252c2d"
+cursor_bg = "#c7c7a5"
 cursor_border = "#c7c7a5"
-cursor_fg = "#e3e3c8"
+cursor_fg = "#171e1f"
 
 selection_bg = "#c7c7a5"
 selection_fg = "#171e1f"

--- a/themes/wezterm/base16-darktooth.toml
+++ b/themes/wezterm/base16-darktooth.toml
@@ -4,9 +4,9 @@
 background = "#1d2021"
 foreground = "#a89984"
 
-cursor_bg = "#32302f"
+cursor_bg = "#a89984"
 cursor_border = "#a89984"
-cursor_fg = "#d5c4a1"
+cursor_fg = "#1d2021"
 
 selection_bg = "#a89984"
 selection_fg = "#1d2021"

--- a/themes/wezterm/base16-darkviolet.toml
+++ b/themes/wezterm/base16-darkviolet.toml
@@ -4,9 +4,9 @@
 background = "#000000"
 foreground = "#b08ae6"
 
-cursor_bg = "#231a40"
+cursor_bg = "#b08ae6"
 cursor_border = "#b08ae6"
-cursor_fg = "#9045e6"
+cursor_fg = "#000000"
 
 selection_bg = "#b08ae6"
 selection_fg = "#000000"

--- a/themes/wezterm/base16-decaf.toml
+++ b/themes/wezterm/base16-decaf.toml
@@ -4,9 +4,9 @@
 background = "#2d2d2d"
 foreground = "#cccccc"
 
-cursor_bg = "#393939"
+cursor_bg = "#cccccc"
 cursor_border = "#cccccc"
-cursor_fg = "#e0e0e0"
+cursor_fg = "#2d2d2d"
 
 selection_bg = "#cccccc"
 selection_fg = "#2d2d2d"

--- a/themes/wezterm/base16-deep-oceanic-next.toml
+++ b/themes/wezterm/base16-deep-oceanic-next.toml
@@ -4,9 +4,9 @@
 background = "#001c1f"
 foreground = "#d4e1e8"
 
-cursor_bg = "#002931"
+cursor_bg = "#d4e1e8"
 cursor_border = "#d4e1e8"
-cursor_fg = "#e0e9ef"
+cursor_fg = "#001c1f"
 
 selection_bg = "#d4e1e8"
 selection_fg = "#001c1f"

--- a/themes/wezterm/base16-default-dark.toml
+++ b/themes/wezterm/base16-default-dark.toml
@@ -4,9 +4,9 @@
 background = "#181818"
 foreground = "#d8d8d8"
 
-cursor_bg = "#282828"
+cursor_bg = "#d8d8d8"
 cursor_border = "#d8d8d8"
-cursor_fg = "#e8e8e8"
+cursor_fg = "#181818"
 
 selection_bg = "#d8d8d8"
 selection_fg = "#181818"

--- a/themes/wezterm/base16-default-light.toml
+++ b/themes/wezterm/base16-default-light.toml
@@ -4,9 +4,9 @@
 background = "#f8f8f8"
 foreground = "#383838"
 
-cursor_bg = "#e8e8e8"
+cursor_bg = "#383838"
 cursor_border = "#383838"
-cursor_fg = "#282828"
+cursor_fg = "#f8f8f8"
 
 selection_bg = "#383838"
 selection_fg = "#f8f8f8"

--- a/themes/wezterm/base16-digital-rain.toml
+++ b/themes/wezterm/base16-digital-rain.toml
@@ -4,9 +4,9 @@
 background = "#000000"
 foreground = "#00ff00"
 
-cursor_bg = "#4a806c"
+cursor_bg = "#00ff00"
 cursor_border = "#00ff00"
-cursor_fg = "#c4cec4"
+cursor_fg = "#000000"
 
 selection_bg = "#00ff00"
 selection_fg = "#000000"

--- a/themes/wezterm/base16-dirtysea.toml
+++ b/themes/wezterm/base16-dirtysea.toml
@@ -4,9 +4,9 @@
 background = "#e0e0e0"
 foreground = "#000000"
 
-cursor_bg = "#d0dad0"
+cursor_bg = "#000000"
 cursor_border = "#000000"
-cursor_fg = "#f8f8f8"
+cursor_fg = "#e0e0e0"
 
 selection_bg = "#000000"
 selection_fg = "#e0e0e0"

--- a/themes/wezterm/base16-dracula.toml
+++ b/themes/wezterm/base16-dracula.toml
@@ -4,9 +4,9 @@
 background = "#282a36"
 foreground = "#f8f8f2"
 
-cursor_bg = "#363447"
+cursor_bg = "#f8f8f2"
 cursor_border = "#f8f8f2"
-cursor_fg = "#f0f1f4"
+cursor_fg = "#282a36"
 
 selection_bg = "#f8f8f2"
 selection_fg = "#282a36"

--- a/themes/wezterm/base16-edge-dark.toml
+++ b/themes/wezterm/base16-edge-dark.toml
@@ -4,9 +4,9 @@
 background = "#262729"
 foreground = "#b7bec9"
 
-cursor_bg = "#88909f"
+cursor_bg = "#b7bec9"
 cursor_border = "#b7bec9"
-cursor_fg = "#d390e7"
+cursor_fg = "#262729"
 
 selection_bg = "#b7bec9"
 selection_fg = "#262729"

--- a/themes/wezterm/base16-edge-light.toml
+++ b/themes/wezterm/base16-edge-light.toml
@@ -4,9 +4,9 @@
 background = "#fafafa"
 foreground = "#5e646f"
 
-cursor_bg = "#7c9f4b"
+cursor_bg = "#5e646f"
 cursor_border = "#5e646f"
-cursor_fg = "#b870ce"
+cursor_fg = "#fafafa"
 
 selection_bg = "#5e646f"
 selection_fg = "#fafafa"

--- a/themes/wezterm/base16-eighties.toml
+++ b/themes/wezterm/base16-eighties.toml
@@ -4,9 +4,9 @@
 background = "#2d2d2d"
 foreground = "#d3d0c8"
 
-cursor_bg = "#393939"
+cursor_bg = "#d3d0c8"
 cursor_border = "#d3d0c8"
-cursor_fg = "#e8e6df"
+cursor_fg = "#2d2d2d"
 
 selection_bg = "#d3d0c8"
 selection_fg = "#2d2d2d"

--- a/themes/wezterm/base16-embers-light.toml
+++ b/themes/wezterm/base16-embers-light.toml
@@ -4,9 +4,9 @@
 background = "#d1d6db"
 foreground = "#323b43"
 
-cursor_bg = "#aeb6be"
+cursor_bg = "#323b43"
 cursor_border = "#323b43"
-cursor_fg = "#20262c"
+cursor_fg = "#d1d6db"
 
 selection_bg = "#323b43"
 selection_fg = "#d1d6db"

--- a/themes/wezterm/base16-embers.toml
+++ b/themes/wezterm/base16-embers.toml
@@ -4,9 +4,9 @@
 background = "#16130f"
 foreground = "#a39a90"
 
-cursor_bg = "#2c2620"
+cursor_bg = "#a39a90"
 cursor_border = "#a39a90"
-cursor_fg = "#beb6ae"
+cursor_fg = "#16130f"
 
 selection_bg = "#a39a90"
 selection_fg = "#16130f"

--- a/themes/wezterm/base16-emil.toml
+++ b/themes/wezterm/base16-emil.toml
@@ -4,9 +4,9 @@
 background = "#efefef"
 foreground = "#313145"
 
-cursor_bg = "#bebed2"
+cursor_bg = "#313145"
 cursor_border = "#313145"
-cursor_fg = "#22223a"
+cursor_fg = "#efefef"
 
 selection_bg = "#313145"
 selection_fg = "#efefef"

--- a/themes/wezterm/base16-equilibrium-dark.toml
+++ b/themes/wezterm/base16-equilibrium-dark.toml
@@ -4,9 +4,9 @@
 background = "#0c1118"
 foreground = "#afaba2"
 
-cursor_bg = "#181c22"
+cursor_bg = "#afaba2"
 cursor_border = "#afaba2"
-cursor_fg = "#cac6bd"
+cursor_fg = "#0c1118"
 
 selection_bg = "#afaba2"
 selection_fg = "#0c1118"

--- a/themes/wezterm/base16-equilibrium-gray-dark.toml
+++ b/themes/wezterm/base16-equilibrium-gray-dark.toml
@@ -4,9 +4,9 @@
 background = "#111111"
 foreground = "#ababab"
 
-cursor_bg = "#1b1b1b"
+cursor_bg = "#ababab"
 cursor_border = "#ababab"
-cursor_fg = "#c6c6c6"
+cursor_fg = "#111111"
 
 selection_bg = "#ababab"
 selection_fg = "#111111"

--- a/themes/wezterm/base16-equilibrium-gray-light.toml
+++ b/themes/wezterm/base16-equilibrium-gray-light.toml
@@ -4,9 +4,9 @@
 background = "#f1f1f1"
 foreground = "#474747"
 
-cursor_bg = "#e2e2e2"
+cursor_bg = "#474747"
 cursor_border = "#474747"
-cursor_fg = "#303030"
+cursor_fg = "#f1f1f1"
 
 selection_bg = "#474747"
 selection_fg = "#f1f1f1"

--- a/themes/wezterm/base16-equilibrium-light.toml
+++ b/themes/wezterm/base16-equilibrium-light.toml
@@ -4,9 +4,9 @@
 background = "#f5f0e7"
 foreground = "#43474e"
 
-cursor_bg = "#e7e2d9"
+cursor_bg = "#43474e"
 cursor_border = "#43474e"
-cursor_fg = "#2c3138"
+cursor_fg = "#f5f0e7"
 
 selection_bg = "#43474e"
 selection_fg = "#f5f0e7"

--- a/themes/wezterm/base16-eris.toml
+++ b/themes/wezterm/base16-eris.toml
@@ -4,9 +4,9 @@
 background = "#0a0920"
 foreground = "#606bac"
 
-cursor_bg = "#13133a"
+cursor_bg = "#606bac"
 cursor_border = "#606bac"
-cursor_fg = "#7986c5"
+cursor_fg = "#0a0920"
 
 selection_bg = "#606bac"
 selection_fg = "#0a0920"

--- a/themes/wezterm/base16-espresso.toml
+++ b/themes/wezterm/base16-espresso.toml
@@ -4,9 +4,9 @@
 background = "#2d2d2d"
 foreground = "#cccccc"
 
-cursor_bg = "#393939"
+cursor_bg = "#cccccc"
 cursor_border = "#cccccc"
-cursor_fg = "#e0e0e0"
+cursor_fg = "#2d2d2d"
 
 selection_bg = "#cccccc"
 selection_fg = "#2d2d2d"

--- a/themes/wezterm/base16-eva-dim.toml
+++ b/themes/wezterm/base16-eva-dim.toml
@@ -4,9 +4,9 @@
 background = "#2a3b4d"
 foreground = "#9fa2a6"
 
-cursor_bg = "#3d566f"
+cursor_bg = "#9fa2a6"
 cursor_border = "#9fa2a6"
-cursor_fg = "#d6d7d9"
+cursor_fg = "#2a3b4d"
 
 selection_bg = "#9fa2a6"
 selection_fg = "#2a3b4d"

--- a/themes/wezterm/base16-eva.toml
+++ b/themes/wezterm/base16-eva.toml
@@ -4,9 +4,9 @@
 background = "#2a3b4d"
 foreground = "#9fa2a6"
 
-cursor_bg = "#3d566f"
+cursor_bg = "#9fa2a6"
 cursor_border = "#9fa2a6"
-cursor_fg = "#d6d7d9"
+cursor_fg = "#2a3b4d"
 
 selection_bg = "#9fa2a6"
 selection_fg = "#2a3b4d"

--- a/themes/wezterm/base16-evenok-dark.toml
+++ b/themes/wezterm/base16-evenok-dark.toml
@@ -4,9 +4,9 @@
 background = "#000000"
 foreground = "#d0d0d0"
 
-cursor_bg = "#202020"
+cursor_bg = "#d0d0d0"
 cursor_border = "#d0d0d0"
-cursor_fg = "#e0e0e0"
+cursor_fg = "#000000"
 
 selection_bg = "#d0d0d0"
 selection_fg = "#000000"

--- a/themes/wezterm/base16-everforest-dark-hard.toml
+++ b/themes/wezterm/base16-everforest-dark-hard.toml
@@ -4,9 +4,9 @@
 background = "#272e33"
 foreground = "#d3c6aa"
 
-cursor_bg = "#2e383c"
+cursor_bg = "#d3c6aa"
 cursor_border = "#d3c6aa"
-cursor_fg = "#edeada"
+cursor_fg = "#272e33"
 
 selection_bg = "#d3c6aa"
 selection_fg = "#272e33"

--- a/themes/wezterm/base16-everforest-dark-soft.toml
+++ b/themes/wezterm/base16-everforest-dark-soft.toml
@@ -4,9 +4,9 @@
 background = "#333c43"
 foreground = "#d3c6aa"
 
-cursor_bg = "#3a464c"
+cursor_bg = "#d3c6aa"
 cursor_border = "#d3c6aa"
-cursor_fg = "#ddd8be"
+cursor_fg = "#333c43"
 
 selection_bg = "#d3c6aa"
 selection_fg = "#333c43"

--- a/themes/wezterm/base16-everforest.toml
+++ b/themes/wezterm/base16-everforest.toml
@@ -4,9 +4,9 @@
 background = "#2d353b"
 foreground = "#d3c6aa"
 
-cursor_bg = "#343f44"
+cursor_bg = "#d3c6aa"
 cursor_border = "#d3c6aa"
-cursor_fg = "#e6e2cc"
+cursor_fg = "#2d353b"
 
 selection_bg = "#d3c6aa"
 selection_fg = "#2d353b"

--- a/themes/wezterm/base16-flat.toml
+++ b/themes/wezterm/base16-flat.toml
@@ -4,9 +4,9 @@
 background = "#2c3e50"
 foreground = "#e0e0e0"
 
-cursor_bg = "#34495e"
+cursor_bg = "#e0e0e0"
 cursor_border = "#e0e0e0"
-cursor_fg = "#f5f5f5"
+cursor_fg = "#2c3e50"
 
 selection_bg = "#e0e0e0"
 selection_fg = "#2c3e50"

--- a/themes/wezterm/base16-framer.toml
+++ b/themes/wezterm/base16-framer.toml
@@ -4,9 +4,9 @@
 background = "#181818"
 foreground = "#d0d0d0"
 
-cursor_bg = "#151515"
+cursor_bg = "#d0d0d0"
 cursor_border = "#d0d0d0"
-cursor_fg = "#e8e8e8"
+cursor_fg = "#181818"
 
 selection_bg = "#d0d0d0"
 selection_fg = "#181818"

--- a/themes/wezterm/base16-fruit-soda.toml
+++ b/themes/wezterm/base16-fruit-soda.toml
@@ -4,9 +4,9 @@
 background = "#f1ecf1"
 foreground = "#515151"
 
-cursor_bg = "#e0dee0"
+cursor_bg = "#515151"
 cursor_border = "#515151"
-cursor_fg = "#474545"
+cursor_fg = "#f1ecf1"
 
 selection_bg = "#515151"
 selection_fg = "#f1ecf1"

--- a/themes/wezterm/base16-gigavolt.toml
+++ b/themes/wezterm/base16-gigavolt.toml
@@ -4,9 +4,9 @@
 background = "#202126"
 foreground = "#e9e7e1"
 
-cursor_bg = "#2d303d"
+cursor_bg = "#e9e7e1"
 cursor_border = "#e9e7e1"
-cursor_fg = "#eff0f9"
+cursor_fg = "#202126"
 
 selection_bg = "#e9e7e1"
 selection_fg = "#202126"

--- a/themes/wezterm/base16-github-dark.toml
+++ b/themes/wezterm/base16-github-dark.toml
@@ -4,9 +4,9 @@
 background = "#161b22"
 foreground = "#c9d1d9"
 
-cursor_bg = "#30363d"
+cursor_bg = "#c9d1d9"
 cursor_border = "#c9d1d9"
-cursor_fg = "#f0f6fc"
+cursor_fg = "#161b22"
 
 selection_bg = "#c9d1d9"
 selection_fg = "#161b22"

--- a/themes/wezterm/base16-github.toml
+++ b/themes/wezterm/base16-github.toml
@@ -4,9 +4,9 @@
 background = "#eaeef2"
 foreground = "#424a53"
 
-cursor_bg = "#d0d7de"
+cursor_bg = "#424a53"
 cursor_border = "#424a53"
-cursor_fg = "#32383f"
+cursor_fg = "#eaeef2"
 
 selection_bg = "#424a53"
 selection_fg = "#eaeef2"

--- a/themes/wezterm/base16-google-dark.toml
+++ b/themes/wezterm/base16-google-dark.toml
@@ -4,9 +4,9 @@
 background = "#1d1f21"
 foreground = "#c5c8c6"
 
-cursor_bg = "#282a2e"
+cursor_bg = "#c5c8c6"
 cursor_border = "#c5c8c6"
-cursor_fg = "#e0e0e0"
+cursor_fg = "#1d1f21"
 
 selection_bg = "#c5c8c6"
 selection_fg = "#1d1f21"

--- a/themes/wezterm/base16-google-light.toml
+++ b/themes/wezterm/base16-google-light.toml
@@ -4,9 +4,9 @@
 background = "#ffffff"
 foreground = "#373b41"
 
-cursor_bg = "#e0e0e0"
+cursor_bg = "#373b41"
 cursor_border = "#373b41"
-cursor_fg = "#282a2e"
+cursor_fg = "#ffffff"
 
 selection_bg = "#373b41"
 selection_fg = "#ffffff"

--- a/themes/wezterm/base16-gotham.toml
+++ b/themes/wezterm/base16-gotham.toml
@@ -4,9 +4,9 @@
 background = "#0c1014"
 foreground = "#599cab"
 
-cursor_bg = "#11151c"
+cursor_bg = "#599cab"
 cursor_border = "#599cab"
-cursor_fg = "#99d1ce"
+cursor_fg = "#0c1014"
 
 selection_bg = "#599cab"
 selection_fg = "#0c1014"

--- a/themes/wezterm/base16-grayscale-dark.toml
+++ b/themes/wezterm/base16-grayscale-dark.toml
@@ -4,9 +4,9 @@
 background = "#101010"
 foreground = "#b9b9b9"
 
-cursor_bg = "#252525"
+cursor_bg = "#b9b9b9"
 cursor_border = "#b9b9b9"
-cursor_fg = "#e3e3e3"
+cursor_fg = "#101010"
 
 selection_bg = "#b9b9b9"
 selection_fg = "#101010"

--- a/themes/wezterm/base16-grayscale-light.toml
+++ b/themes/wezterm/base16-grayscale-light.toml
@@ -4,9 +4,9 @@
 background = "#f7f7f7"
 foreground = "#464646"
 
-cursor_bg = "#e3e3e3"
+cursor_bg = "#464646"
 cursor_border = "#464646"
-cursor_fg = "#252525"
+cursor_fg = "#f7f7f7"
 
 selection_bg = "#464646"
 selection_fg = "#f7f7f7"

--- a/themes/wezterm/base16-greenscreen.toml
+++ b/themes/wezterm/base16-greenscreen.toml
@@ -4,9 +4,9 @@
 background = "#001100"
 foreground = "#00bb00"
 
-cursor_bg = "#003300"
+cursor_bg = "#00bb00"
 cursor_border = "#00bb00"
-cursor_fg = "#00dd00"
+cursor_fg = "#001100"
 
 selection_bg = "#00bb00"
 selection_fg = "#001100"

--- a/themes/wezterm/base16-gruber.toml
+++ b/themes/wezterm/base16-gruber.toml
@@ -4,9 +4,9 @@
 background = "#181818"
 foreground = "#f4f4ff"
 
-cursor_bg = "#453d41"
+cursor_bg = "#f4f4ff"
 cursor_border = "#f4f4ff"
-cursor_fg = "#f5f5f5"
+cursor_fg = "#181818"
 
 selection_bg = "#f4f4ff"
 selection_fg = "#181818"

--- a/themes/wezterm/base16-gruvbox-dark-hard.toml
+++ b/themes/wezterm/base16-gruvbox-dark-hard.toml
@@ -4,9 +4,9 @@
 background = "#1d2021"
 foreground = "#d5c4a1"
 
-cursor_bg = "#3c3836"
+cursor_bg = "#d5c4a1"
 cursor_border = "#d5c4a1"
-cursor_fg = "#ebdbb2"
+cursor_fg = "#1d2021"
 
 selection_bg = "#d5c4a1"
 selection_fg = "#1d2021"

--- a/themes/wezterm/base16-gruvbox-dark-medium.toml
+++ b/themes/wezterm/base16-gruvbox-dark-medium.toml
@@ -4,9 +4,9 @@
 background = "#282828"
 foreground = "#d5c4a1"
 
-cursor_bg = "#3c3836"
+cursor_bg = "#d5c4a1"
 cursor_border = "#d5c4a1"
-cursor_fg = "#ebdbb2"
+cursor_fg = "#282828"
 
 selection_bg = "#d5c4a1"
 selection_fg = "#282828"

--- a/themes/wezterm/base16-gruvbox-dark-pale.toml
+++ b/themes/wezterm/base16-gruvbox-dark-pale.toml
@@ -4,9 +4,9 @@
 background = "#262626"
 foreground = "#dab997"
 
-cursor_bg = "#3a3a3a"
+cursor_bg = "#dab997"
 cursor_border = "#dab997"
-cursor_fg = "#d5c4a1"
+cursor_fg = "#262626"
 
 selection_bg = "#dab997"
 selection_fg = "#262626"

--- a/themes/wezterm/base16-gruvbox-dark-soft.toml
+++ b/themes/wezterm/base16-gruvbox-dark-soft.toml
@@ -4,9 +4,9 @@
 background = "#32302f"
 foreground = "#d5c4a1"
 
-cursor_bg = "#3c3836"
+cursor_bg = "#d5c4a1"
 cursor_border = "#d5c4a1"
-cursor_fg = "#ebdbb2"
+cursor_fg = "#32302f"
 
 selection_bg = "#d5c4a1"
 selection_fg = "#32302f"

--- a/themes/wezterm/base16-gruvbox-dark.toml
+++ b/themes/wezterm/base16-gruvbox-dark.toml
@@ -4,9 +4,9 @@
 background = "#282828"
 foreground = "#ebdbb2"
 
-cursor_bg = "#3c3836"
+cursor_bg = "#ebdbb2"
 cursor_border = "#ebdbb2"
-cursor_fg = "#fbf1c7"
+cursor_fg = "#282828"
 
 selection_bg = "#ebdbb2"
 selection_fg = "#282828"

--- a/themes/wezterm/base16-gruvbox-light-hard.toml
+++ b/themes/wezterm/base16-gruvbox-light-hard.toml
@@ -4,9 +4,9 @@
 background = "#f9f5d7"
 foreground = "#504945"
 
-cursor_bg = "#ebdbb2"
+cursor_bg = "#504945"
 cursor_border = "#504945"
-cursor_fg = "#3c3836"
+cursor_fg = "#f9f5d7"
 
 selection_bg = "#504945"
 selection_fg = "#f9f5d7"

--- a/themes/wezterm/base16-gruvbox-light-medium.toml
+++ b/themes/wezterm/base16-gruvbox-light-medium.toml
@@ -4,9 +4,9 @@
 background = "#fbf1c7"
 foreground = "#504945"
 
-cursor_bg = "#ebdbb2"
+cursor_bg = "#504945"
 cursor_border = "#504945"
-cursor_fg = "#3c3836"
+cursor_fg = "#fbf1c7"
 
 selection_bg = "#504945"
 selection_fg = "#fbf1c7"

--- a/themes/wezterm/base16-gruvbox-light-soft.toml
+++ b/themes/wezterm/base16-gruvbox-light-soft.toml
@@ -4,9 +4,9 @@
 background = "#f2e5bc"
 foreground = "#504945"
 
-cursor_bg = "#ebdbb2"
+cursor_bg = "#504945"
 cursor_border = "#504945"
-cursor_fg = "#3c3836"
+cursor_fg = "#f2e5bc"
 
 selection_bg = "#504945"
 selection_fg = "#f2e5bc"

--- a/themes/wezterm/base16-gruvbox-light.toml
+++ b/themes/wezterm/base16-gruvbox-light.toml
@@ -4,9 +4,9 @@
 background = "#fbf1c7"
 foreground = "#3c3836"
 
-cursor_bg = "#ebdbb2"
+cursor_bg = "#3c3836"
 cursor_border = "#3c3836"
-cursor_fg = "#282828"
+cursor_fg = "#fbf1c7"
 
 selection_bg = "#3c3836"
 selection_fg = "#fbf1c7"

--- a/themes/wezterm/base16-gruvbox-material-dark-hard.toml
+++ b/themes/wezterm/base16-gruvbox-material-dark-hard.toml
@@ -4,9 +4,9 @@
 background = "#202020"
 foreground = "#ddc7a1"
 
-cursor_bg = "#2a2827"
+cursor_bg = "#ddc7a1"
 cursor_border = "#ddc7a1"
-cursor_fg = "#ebdbb2"
+cursor_fg = "#202020"
 
 selection_bg = "#ddc7a1"
 selection_fg = "#202020"

--- a/themes/wezterm/base16-gruvbox-material-dark-medium.toml
+++ b/themes/wezterm/base16-gruvbox-material-dark-medium.toml
@@ -4,9 +4,9 @@
 background = "#292828"
 foreground = "#ddc7a1"
 
-cursor_bg = "#32302f"
+cursor_bg = "#ddc7a1"
 cursor_border = "#ddc7a1"
-cursor_fg = "#ebdbb2"
+cursor_fg = "#292828"
 
 selection_bg = "#ddc7a1"
 selection_fg = "#292828"

--- a/themes/wezterm/base16-gruvbox-material-dark-soft.toml
+++ b/themes/wezterm/base16-gruvbox-material-dark-soft.toml
@@ -4,9 +4,9 @@
 background = "#32302f"
 foreground = "#ddc7a1"
 
-cursor_bg = "#3c3836"
+cursor_bg = "#ddc7a1"
 cursor_border = "#ddc7a1"
-cursor_fg = "#ebdbb2"
+cursor_fg = "#32302f"
 
 selection_bg = "#ddc7a1"
 selection_fg = "#32302f"

--- a/themes/wezterm/base16-gruvbox-material-light-hard.toml
+++ b/themes/wezterm/base16-gruvbox-material-light-hard.toml
@@ -4,9 +4,9 @@
 background = "#f9f5d7"
 foreground = "#654735"
 
-cursor_bg = "#fbf1c7"
+cursor_bg = "#654735"
 cursor_border = "#654735"
-cursor_fg = "#3c3836"
+cursor_fg = "#f9f5d7"
 
 selection_bg = "#654735"
 selection_fg = "#f9f5d7"

--- a/themes/wezterm/base16-gruvbox-material-light-medium.toml
+++ b/themes/wezterm/base16-gruvbox-material-light-medium.toml
@@ -4,9 +4,9 @@
 background = "#fbf1c7"
 foreground = "#654735"
 
-cursor_bg = "#f2e5bc"
+cursor_bg = "#654735"
 cursor_border = "#654735"
-cursor_fg = "#3c3836"
+cursor_fg = "#fbf1c7"
 
 selection_bg = "#654735"
 selection_fg = "#fbf1c7"

--- a/themes/wezterm/base16-gruvbox-material-light-soft.toml
+++ b/themes/wezterm/base16-gruvbox-material-light-soft.toml
@@ -4,9 +4,9 @@
 background = "#f2e5bc"
 foreground = "#654735"
 
-cursor_bg = "#ebdbb2"
+cursor_bg = "#654735"
 cursor_border = "#654735"
-cursor_fg = "#3c3836"
+cursor_fg = "#f2e5bc"
 
 selection_bg = "#654735"
 selection_fg = "#f2e5bc"

--- a/themes/wezterm/base16-hardcore.toml
+++ b/themes/wezterm/base16-hardcore.toml
@@ -4,9 +4,9 @@
 background = "#212121"
 foreground = "#cdcdcd"
 
-cursor_bg = "#303030"
+cursor_bg = "#cdcdcd"
 cursor_border = "#cdcdcd"
-cursor_fg = "#e5e5e5"
+cursor_fg = "#212121"
 
 selection_bg = "#cdcdcd"
 selection_fg = "#212121"

--- a/themes/wezterm/base16-harmonic16-dark.toml
+++ b/themes/wezterm/base16-harmonic16-dark.toml
@@ -4,9 +4,9 @@
 background = "#0b1c2c"
 foreground = "#cbd6e2"
 
-cursor_bg = "#223b54"
+cursor_bg = "#cbd6e2"
 cursor_border = "#cbd6e2"
-cursor_fg = "#e5ebf1"
+cursor_fg = "#0b1c2c"
 
 selection_bg = "#cbd6e2"
 selection_fg = "#0b1c2c"

--- a/themes/wezterm/base16-harmonic16-light.toml
+++ b/themes/wezterm/base16-harmonic16-light.toml
@@ -4,9 +4,9 @@
 background = "#f7f9fb"
 foreground = "#405c79"
 
-cursor_bg = "#e5ebf1"
+cursor_bg = "#405c79"
 cursor_border = "#405c79"
-cursor_fg = "#223b54"
+cursor_fg = "#f7f9fb"
 
 selection_bg = "#405c79"
 selection_fg = "#f7f9fb"

--- a/themes/wezterm/base16-heetch-light.toml
+++ b/themes/wezterm/base16-heetch-light.toml
@@ -4,9 +4,9 @@
 background = "#feffff"
 foreground = "#5a496e"
 
-cursor_bg = "#392551"
+cursor_bg = "#5a496e"
 cursor_border = "#5a496e"
-cursor_fg = "#470546"
+cursor_fg = "#feffff"
 
 selection_bg = "#5a496e"
 selection_fg = "#feffff"

--- a/themes/wezterm/base16-heetch.toml
+++ b/themes/wezterm/base16-heetch.toml
@@ -4,9 +4,9 @@
 background = "#190134"
 foreground = "#bdb6c5"
 
-cursor_bg = "#392551"
+cursor_bg = "#bdb6c5"
 cursor_border = "#bdb6c5"
-cursor_fg = "#dedae2"
+cursor_fg = "#190134"
 
 selection_bg = "#bdb6c5"
 selection_fg = "#190134"

--- a/themes/wezterm/base16-helios.toml
+++ b/themes/wezterm/base16-helios.toml
@@ -4,9 +4,9 @@
 background = "#1d2021"
 foreground = "#d5d5d5"
 
-cursor_bg = "#383c3e"
+cursor_bg = "#d5d5d5"
 cursor_border = "#d5d5d5"
-cursor_fg = "#dddddd"
+cursor_fg = "#1d2021"
 
 selection_bg = "#d5d5d5"
 selection_fg = "#1d2021"

--- a/themes/wezterm/base16-hopscotch.toml
+++ b/themes/wezterm/base16-hopscotch.toml
@@ -4,9 +4,9 @@
 background = "#322931"
 foreground = "#b9b5b8"
 
-cursor_bg = "#433b42"
+cursor_bg = "#b9b5b8"
 cursor_border = "#b9b5b8"
-cursor_fg = "#d5d3d5"
+cursor_fg = "#322931"
 
 selection_bg = "#b9b5b8"
 selection_fg = "#322931"

--- a/themes/wezterm/base16-horizon-dark.toml
+++ b/themes/wezterm/base16-horizon-dark.toml
@@ -4,9 +4,9 @@
 background = "#1c1e26"
 foreground = "#cbced0"
 
-cursor_bg = "#232530"
+cursor_bg = "#cbced0"
 cursor_border = "#cbced0"
-cursor_fg = "#dcdfe4"
+cursor_fg = "#1c1e26"
 
 selection_bg = "#cbced0"
 selection_fg = "#1c1e26"

--- a/themes/wezterm/base16-horizon-light.toml
+++ b/themes/wezterm/base16-horizon-light.toml
@@ -4,9 +4,9 @@
 background = "#fdf0ed"
 foreground = "#403c3d"
 
-cursor_bg = "#fadad1"
+cursor_bg = "#403c3d"
 cursor_border = "#403c3d"
-cursor_fg = "#302c2d"
+cursor_fg = "#fdf0ed"
 
 selection_bg = "#403c3d"
 selection_fg = "#fdf0ed"

--- a/themes/wezterm/base16-horizon-terminal-dark.toml
+++ b/themes/wezterm/base16-horizon-terminal-dark.toml
@@ -4,9 +4,9 @@
 background = "#1c1e26"
 foreground = "#cbced0"
 
-cursor_bg = "#232530"
+cursor_bg = "#cbced0"
 cursor_border = "#cbced0"
-cursor_fg = "#dcdfe4"
+cursor_fg = "#1c1e26"
 
 selection_bg = "#cbced0"
 selection_fg = "#1c1e26"

--- a/themes/wezterm/base16-horizon-terminal-light.toml
+++ b/themes/wezterm/base16-horizon-terminal-light.toml
@@ -4,9 +4,9 @@
 background = "#fdf0ed"
 foreground = "#403c3d"
 
-cursor_bg = "#fadad1"
+cursor_bg = "#403c3d"
 cursor_border = "#403c3d"
-cursor_fg = "#302c2d"
+cursor_fg = "#fdf0ed"
 
 selection_bg = "#403c3d"
 selection_fg = "#fdf0ed"

--- a/themes/wezterm/base16-humanoid-dark.toml
+++ b/themes/wezterm/base16-humanoid-dark.toml
@@ -4,9 +4,9 @@
 background = "#232629"
 foreground = "#f8f8f2"
 
-cursor_bg = "#333b3d"
+cursor_bg = "#f8f8f2"
 cursor_border = "#f8f8f2"
-cursor_fg = "#fcfcf6"
+cursor_fg = "#232629"
 
 selection_bg = "#f8f8f2"
 selection_fg = "#232629"

--- a/themes/wezterm/base16-humanoid-light.toml
+++ b/themes/wezterm/base16-humanoid-light.toml
@@ -4,9 +4,9 @@
 background = "#f8f8f2"
 foreground = "#232629"
 
-cursor_bg = "#efefe9"
+cursor_bg = "#232629"
 cursor_border = "#232629"
-cursor_fg = "#2f3337"
+cursor_fg = "#f8f8f2"
 
 selection_bg = "#232629"
 selection_fg = "#f8f8f2"

--- a/themes/wezterm/base16-ia-dark.toml
+++ b/themes/wezterm/base16-ia-dark.toml
@@ -4,9 +4,9 @@
 background = "#1a1a1a"
 foreground = "#cccccc"
 
-cursor_bg = "#222222"
+cursor_bg = "#cccccc"
 cursor_border = "#cccccc"
-cursor_fg = "#e8e8e8"
+cursor_fg = "#1a1a1a"
 
 selection_bg = "#cccccc"
 selection_fg = "#1a1a1a"

--- a/themes/wezterm/base16-ia-light.toml
+++ b/themes/wezterm/base16-ia-light.toml
@@ -4,9 +4,9 @@
 background = "#f6f6f6"
 foreground = "#181818"
 
-cursor_bg = "#dedede"
+cursor_bg = "#181818"
 cursor_border = "#181818"
-cursor_fg = "#e8e8e8"
+cursor_fg = "#f6f6f6"
 
 selection_bg = "#181818"
 selection_fg = "#f6f6f6"

--- a/themes/wezterm/base16-icy.toml
+++ b/themes/wezterm/base16-icy.toml
@@ -4,9 +4,9 @@
 background = "#021012"
 foreground = "#095b67"
 
-cursor_bg = "#031619"
+cursor_bg = "#095b67"
 cursor_border = "#095b67"
-cursor_fg = "#0c7c8c"
+cursor_fg = "#021012"
 
 selection_bg = "#095b67"
 selection_fg = "#021012"

--- a/themes/wezterm/base16-irblack.toml
+++ b/themes/wezterm/base16-irblack.toml
@@ -4,9 +4,9 @@
 background = "#000000"
 foreground = "#b5b3aa"
 
-cursor_bg = "#242422"
+cursor_bg = "#b5b3aa"
 cursor_border = "#b5b3aa"
-cursor_fg = "#d9d7cc"
+cursor_fg = "#000000"
 
 selection_bg = "#b5b3aa"
 selection_fg = "#000000"

--- a/themes/wezterm/base16-isotope.toml
+++ b/themes/wezterm/base16-isotope.toml
@@ -4,9 +4,9 @@
 background = "#000000"
 foreground = "#d0d0d0"
 
-cursor_bg = "#404040"
+cursor_bg = "#d0d0d0"
 cursor_border = "#d0d0d0"
-cursor_fg = "#e0e0e0"
+cursor_fg = "#000000"
 
 selection_bg = "#d0d0d0"
 selection_fg = "#000000"

--- a/themes/wezterm/base16-jabuti.toml
+++ b/themes/wezterm/base16-jabuti.toml
@@ -4,9 +4,9 @@
 background = "#292a37"
 foreground = "#c0cbe3"
 
-cursor_bg = "#343545"
+cursor_bg = "#c0cbe3"
 cursor_border = "#c0cbe3"
-cursor_fg = "#d9e0ee"
+cursor_fg = "#292a37"
 
 selection_bg = "#c0cbe3"
 selection_fg = "#292a37"

--- a/themes/wezterm/base16-kanagawa-dragon.toml
+++ b/themes/wezterm/base16-kanagawa-dragon.toml
@@ -4,9 +4,9 @@
 background = "#0d0c0c"
 foreground = "#c5c9c5"
 
-cursor_bg = "#1d1c19"
+cursor_bg = "#c5c9c5"
 cursor_border = "#c5c9c5"
-cursor_fg = "#7a8382"
+cursor_fg = "#0d0c0c"
 
 selection_bg = "#c5c9c5"
 selection_fg = "#0d0c0c"

--- a/themes/wezterm/base16-kanagawa.toml
+++ b/themes/wezterm/base16-kanagawa.toml
@@ -4,9 +4,9 @@
 background = "#1f1f28"
 foreground = "#dcd7ba"
 
-cursor_bg = "#16161d"
+cursor_bg = "#dcd7ba"
 cursor_border = "#dcd7ba"
-cursor_fg = "#c8c093"
+cursor_fg = "#1f1f28"
 
 selection_bg = "#dcd7ba"
 selection_fg = "#1f1f28"

--- a/themes/wezterm/base16-katy.toml
+++ b/themes/wezterm/base16-katy.toml
@@ -4,9 +4,9 @@
 background = "#292d3e"
 foreground = "#959dcb"
 
-cursor_bg = "#444267"
+cursor_bg = "#959dcb"
 cursor_border = "#959dcb"
-cursor_fg = "#959dcb"
+cursor_fg = "#292d3e"
 
 selection_bg = "#959dcb"
 selection_fg = "#292d3e"

--- a/themes/wezterm/base16-kimber.toml
+++ b/themes/wezterm/base16-kimber.toml
@@ -4,9 +4,9 @@
 background = "#222222"
 foreground = "#dedee7"
 
-cursor_bg = "#313131"
+cursor_bg = "#dedee7"
 cursor_border = "#dedee7"
-cursor_fg = "#c3c3b4"
+cursor_fg = "#222222"
 
 selection_bg = "#dedee7"
 selection_fg = "#222222"

--- a/themes/wezterm/base16-lime.toml
+++ b/themes/wezterm/base16-lime.toml
@@ -4,9 +4,9 @@
 background = "#1a1a2f"
 foreground = "#818175"
 
-cursor_bg = "#202030"
+cursor_bg = "#818175"
 cursor_border = "#818175"
-cursor_fg = "#fff2d1"
+cursor_fg = "#1a1a2f"
 
 selection_bg = "#818175"
 selection_fg = "#1a1a2f"

--- a/themes/wezterm/base16-macintosh.toml
+++ b/themes/wezterm/base16-macintosh.toml
@@ -4,9 +4,9 @@
 background = "#000000"
 foreground = "#c0c0c0"
 
-cursor_bg = "#404040"
+cursor_bg = "#c0c0c0"
 cursor_border = "#c0c0c0"
-cursor_fg = "#c0c0c0"
+cursor_fg = "#000000"
 
 selection_bg = "#c0c0c0"
 selection_fg = "#000000"

--- a/themes/wezterm/base16-marrakesh.toml
+++ b/themes/wezterm/base16-marrakesh.toml
@@ -4,9 +4,9 @@
 background = "#201602"
 foreground = "#948e48"
 
-cursor_bg = "#302e00"
+cursor_bg = "#948e48"
 cursor_border = "#948e48"
-cursor_fg = "#ccc37a"
+cursor_fg = "#201602"
 
 selection_bg = "#948e48"
 selection_fg = "#201602"

--- a/themes/wezterm/base16-materia.toml
+++ b/themes/wezterm/base16-materia.toml
@@ -4,9 +4,9 @@
 background = "#263238"
 foreground = "#cdd3de"
 
-cursor_bg = "#2c393f"
+cursor_bg = "#cdd3de"
 cursor_border = "#cdd3de"
-cursor_fg = "#d5dbe5"
+cursor_fg = "#263238"
 
 selection_bg = "#cdd3de"
 selection_fg = "#263238"

--- a/themes/wezterm/base16-material-darker.toml
+++ b/themes/wezterm/base16-material-darker.toml
@@ -4,9 +4,9 @@
 background = "#212121"
 foreground = "#eeffff"
 
-cursor_bg = "#303030"
+cursor_bg = "#eeffff"
 cursor_border = "#eeffff"
-cursor_fg = "#eeffff"
+cursor_fg = "#212121"
 
 selection_bg = "#eeffff"
 selection_fg = "#212121"

--- a/themes/wezterm/base16-material-lighter.toml
+++ b/themes/wezterm/base16-material-lighter.toml
@@ -4,9 +4,9 @@
 background = "#fafafa"
 foreground = "#80cbc4"
 
-cursor_bg = "#e7eaec"
+cursor_bg = "#80cbc4"
 cursor_border = "#80cbc4"
-cursor_fg = "#80cbc4"
+cursor_fg = "#fafafa"
 
 selection_bg = "#80cbc4"
 selection_fg = "#fafafa"

--- a/themes/wezterm/base16-material-palenight.toml
+++ b/themes/wezterm/base16-material-palenight.toml
@@ -4,9 +4,9 @@
 background = "#292d3e"
 foreground = "#959dcb"
 
-cursor_bg = "#444267"
+cursor_bg = "#959dcb"
 cursor_border = "#959dcb"
-cursor_fg = "#959dcb"
+cursor_fg = "#292d3e"
 
 selection_bg = "#959dcb"
 selection_fg = "#292d3e"

--- a/themes/wezterm/base16-material-vivid.toml
+++ b/themes/wezterm/base16-material-vivid.toml
@@ -4,9 +4,9 @@
 background = "#202124"
 foreground = "#80868b"
 
-cursor_bg = "#27292c"
+cursor_bg = "#80868b"
 cursor_border = "#80868b"
-cursor_fg = "#9e9e9e"
+cursor_fg = "#202124"
 
 selection_bg = "#80868b"
 selection_fg = "#202124"

--- a/themes/wezterm/base16-material.toml
+++ b/themes/wezterm/base16-material.toml
@@ -4,9 +4,9 @@
 background = "#263238"
 foreground = "#eeffff"
 
-cursor_bg = "#2e3c43"
+cursor_bg = "#eeffff"
 cursor_border = "#eeffff"
-cursor_fg = "#eeffff"
+cursor_fg = "#263238"
 
 selection_bg = "#eeffff"
 selection_fg = "#263238"

--- a/themes/wezterm/base16-measured-dark.toml
+++ b/themes/wezterm/base16-measured-dark.toml
@@ -4,9 +4,9 @@
 background = "#00211f"
 foreground = "#dcdcdc"
 
-cursor_bg = "#003a38"
+cursor_bg = "#dcdcdc"
 cursor_border = "#dcdcdc"
-cursor_fg = "#efefef"
+cursor_fg = "#00211f"
 
 selection_bg = "#dcdcdc"
 selection_fg = "#00211f"

--- a/themes/wezterm/base16-measured-light.toml
+++ b/themes/wezterm/base16-measured-light.toml
@@ -4,9 +4,9 @@
 background = "#fdf9f5"
 foreground = "#292929"
 
-cursor_bg = "#f9f5f1"
+cursor_bg = "#292929"
 cursor_border = "#292929"
-cursor_fg = "#181818"
+cursor_fg = "#fdf9f5"
 
 selection_bg = "#292929"
 selection_fg = "#fdf9f5"

--- a/themes/wezterm/base16-mellow-purple.toml
+++ b/themes/wezterm/base16-mellow-purple.toml
@@ -4,9 +4,9 @@
 background = "#1e0528"
 foreground = "#ffeeff"
 
-cursor_bg = "#1a092d"
+cursor_bg = "#ffeeff"
 cursor_border = "#ffeeff"
-cursor_fg = "#ffeeff"
+cursor_fg = "#1e0528"
 
 selection_bg = "#ffeeff"
 selection_fg = "#1e0528"

--- a/themes/wezterm/base16-mexico-light.toml
+++ b/themes/wezterm/base16-mexico-light.toml
@@ -4,9 +4,9 @@
 background = "#f8f8f8"
 foreground = "#383838"
 
-cursor_bg = "#e8e8e8"
+cursor_bg = "#383838"
 cursor_border = "#383838"
-cursor_fg = "#282828"
+cursor_fg = "#f8f8f8"
 
 selection_bg = "#383838"
 selection_fg = "#f8f8f8"

--- a/themes/wezterm/base16-mocha.toml
+++ b/themes/wezterm/base16-mocha.toml
@@ -4,9 +4,9 @@
 background = "#3b3228"
 foreground = "#d0c8c6"
 
-cursor_bg = "#534636"
+cursor_bg = "#d0c8c6"
 cursor_border = "#d0c8c6"
-cursor_fg = "#e9e1dd"
+cursor_fg = "#3b3228"
 
 selection_bg = "#d0c8c6"
 selection_fg = "#3b3228"

--- a/themes/wezterm/base16-monokai.toml
+++ b/themes/wezterm/base16-monokai.toml
@@ -4,9 +4,9 @@
 background = "#272822"
 foreground = "#f8f8f2"
 
-cursor_bg = "#383830"
+cursor_bg = "#f8f8f2"
 cursor_border = "#f8f8f2"
-cursor_fg = "#f5f4f1"
+cursor_fg = "#272822"
 
 selection_bg = "#f8f8f2"
 selection_fg = "#272822"

--- a/themes/wezterm/base16-moonlight.toml
+++ b/themes/wezterm/base16-moonlight.toml
@@ -4,9 +4,9 @@
 background = "#212337"
 foreground = "#a3ace1"
 
-cursor_bg = "#403c64"
+cursor_bg = "#a3ace1"
 cursor_border = "#a3ace1"
-cursor_fg = "#b4a4f4"
+cursor_fg = "#212337"
 
 selection_bg = "#a3ace1"
 selection_fg = "#212337"

--- a/themes/wezterm/base16-mountain.toml
+++ b/themes/wezterm/base16-mountain.toml
@@ -4,9 +4,9 @@
 background = "#0f0f0f"
 foreground = "#cacaca"
 
-cursor_bg = "#191919"
+cursor_bg = "#cacaca"
 cursor_border = "#cacaca"
-cursor_fg = "#e7e7e7"
+cursor_fg = "#0f0f0f"
 
 selection_bg = "#cacaca"
 selection_fg = "#0f0f0f"

--- a/themes/wezterm/base16-nebula.toml
+++ b/themes/wezterm/base16-nebula.toml
@@ -4,9 +4,9 @@
 background = "#22273b"
 foreground = "#a4a6a9"
 
-cursor_bg = "#414f60"
+cursor_bg = "#a4a6a9"
 cursor_border = "#a4a6a9"
-cursor_fg = "#c7c9cd"
+cursor_fg = "#22273b"
 
 selection_bg = "#a4a6a9"
 selection_fg = "#22273b"

--- a/themes/wezterm/base16-nord-light.toml
+++ b/themes/wezterm/base16-nord-light.toml
@@ -4,9 +4,9 @@
 background = "#e5e9f0"
 foreground = "#2e3440"
 
-cursor_bg = "#c2d0e7"
+cursor_bg = "#2e3440"
 cursor_border = "#2e3440"
-cursor_fg = "#3b4252"
+cursor_fg = "#e5e9f0"
 
 selection_bg = "#2e3440"
 selection_fg = "#e5e9f0"

--- a/themes/wezterm/base16-nord.toml
+++ b/themes/wezterm/base16-nord.toml
@@ -4,9 +4,9 @@
 background = "#2e3440"
 foreground = "#e5e9f0"
 
-cursor_bg = "#3b4252"
+cursor_bg = "#e5e9f0"
 cursor_border = "#e5e9f0"
-cursor_fg = "#eceff4"
+cursor_fg = "#2e3440"
 
 selection_bg = "#e5e9f0"
 selection_fg = "#2e3440"

--- a/themes/wezterm/base16-nova.toml
+++ b/themes/wezterm/base16-nova.toml
@@ -4,9 +4,9 @@
 background = "#3c4c55"
 foreground = "#c5d4dd"
 
-cursor_bg = "#556873"
+cursor_bg = "#c5d4dd"
 cursor_border = "#c5d4dd"
-cursor_fg = "#899ba6"
+cursor_fg = "#3c4c55"
 
 selection_bg = "#c5d4dd"
 selection_fg = "#3c4c55"

--- a/themes/wezterm/base16-ocean.toml
+++ b/themes/wezterm/base16-ocean.toml
@@ -4,9 +4,9 @@
 background = "#2b303b"
 foreground = "#c0c5ce"
 
-cursor_bg = "#343d46"
+cursor_bg = "#c0c5ce"
 cursor_border = "#c0c5ce"
-cursor_fg = "#dfe1e8"
+cursor_fg = "#2b303b"
 
 selection_bg = "#c0c5ce"
 selection_fg = "#2b303b"

--- a/themes/wezterm/base16-oceanicnext.toml
+++ b/themes/wezterm/base16-oceanicnext.toml
@@ -4,9 +4,9 @@
 background = "#1b2b34"
 foreground = "#c0c5ce"
 
-cursor_bg = "#343d46"
+cursor_bg = "#c0c5ce"
 cursor_border = "#c0c5ce"
-cursor_fg = "#cdd3de"
+cursor_fg = "#1b2b34"
 
 selection_bg = "#c0c5ce"
 selection_fg = "#1b2b34"

--- a/themes/wezterm/base16-one-light.toml
+++ b/themes/wezterm/base16-one-light.toml
@@ -4,9 +4,9 @@
 background = "#fafafa"
 foreground = "#383a42"
 
-cursor_bg = "#f0f0f1"
+cursor_bg = "#383a42"
 cursor_border = "#383a42"
-cursor_fg = "#202227"
+cursor_fg = "#fafafa"
 
 selection_bg = "#383a42"
 selection_fg = "#fafafa"

--- a/themes/wezterm/base16-onedark-dark.toml
+++ b/themes/wezterm/base16-onedark-dark.toml
@@ -4,9 +4,9 @@
 background = "#000000"
 foreground = "#abb2bf"
 
-cursor_bg = "#1c1f24"
+cursor_bg = "#abb2bf"
 cursor_border = "#abb2bf"
-cursor_fg = "#b6bdca"
+cursor_fg = "#000000"
 
 selection_bg = "#abb2bf"
 selection_fg = "#000000"

--- a/themes/wezterm/base16-onedark.toml
+++ b/themes/wezterm/base16-onedark.toml
@@ -4,9 +4,9 @@
 background = "#282c34"
 foreground = "#abb2bf"
 
-cursor_bg = "#353b45"
+cursor_bg = "#abb2bf"
 cursor_border = "#abb2bf"
-cursor_fg = "#b6bdca"
+cursor_fg = "#282c34"
 
 selection_bg = "#abb2bf"
 selection_fg = "#282c34"

--- a/themes/wezterm/base16-outrun-dark.toml
+++ b/themes/wezterm/base16-outrun-dark.toml
@@ -4,9 +4,9 @@
 background = "#00002a"
 foreground = "#d0d0fa"
 
-cursor_bg = "#20204a"
+cursor_bg = "#d0d0fa"
 cursor_border = "#d0d0fa"
-cursor_fg = "#e0e0ff"
+cursor_fg = "#00002a"
 
 selection_bg = "#d0d0fa"
 selection_fg = "#00002a"

--- a/themes/wezterm/base16-oxocarbon-dark.toml
+++ b/themes/wezterm/base16-oxocarbon-dark.toml
@@ -4,9 +4,9 @@
 background = "#161616"
 foreground = "#f2f4f8"
 
-cursor_bg = "#262626"
+cursor_bg = "#f2f4f8"
 cursor_border = "#f2f4f8"
-cursor_fg = "#ffffff"
+cursor_fg = "#161616"
 
 selection_bg = "#f2f4f8"
 selection_fg = "#161616"

--- a/themes/wezterm/base16-oxocarbon-light.toml
+++ b/themes/wezterm/base16-oxocarbon-light.toml
@@ -4,9 +4,9 @@
 background = "#f2f4f8"
 foreground = "#393939"
 
-cursor_bg = "#dde1e6"
+cursor_bg = "#393939"
 cursor_border = "#393939"
-cursor_fg = "#525252"
+cursor_fg = "#f2f4f8"
 
 selection_bg = "#393939"
 selection_fg = "#f2f4f8"

--- a/themes/wezterm/base16-pandora.toml
+++ b/themes/wezterm/base16-pandora.toml
@@ -4,9 +4,9 @@
 background = "#131213"
 foreground = "#f15c99"
 
-cursor_bg = "#2f1823"
+cursor_bg = "#f15c99"
 cursor_border = "#f15c99"
-cursor_fg = "#81506a"
+cursor_fg = "#131213"
 
 selection_bg = "#f15c99"
 selection_fg = "#131213"

--- a/themes/wezterm/base16-papercolor-dark.toml
+++ b/themes/wezterm/base16-papercolor-dark.toml
@@ -4,9 +4,9 @@
 background = "#1c1c1c"
 foreground = "#808080"
 
-cursor_bg = "#af005f"
+cursor_bg = "#808080"
 cursor_border = "#808080"
-cursor_fg = "#d7875f"
+cursor_fg = "#1c1c1c"
 
 selection_bg = "#808080"
 selection_fg = "#1c1c1c"

--- a/themes/wezterm/base16-papercolor-light.toml
+++ b/themes/wezterm/base16-papercolor-light.toml
@@ -4,9 +4,9 @@
 background = "#eeeeee"
 foreground = "#444444"
 
-cursor_bg = "#af0000"
+cursor_bg = "#444444"
 cursor_border = "#444444"
-cursor_fg = "#005f87"
+cursor_fg = "#eeeeee"
 
 selection_bg = "#444444"
 selection_fg = "#eeeeee"

--- a/themes/wezterm/base16-paraiso.toml
+++ b/themes/wezterm/base16-paraiso.toml
@@ -4,9 +4,9 @@
 background = "#2f1e2e"
 foreground = "#a39e9b"
 
-cursor_bg = "#41323f"
+cursor_bg = "#a39e9b"
 cursor_border = "#a39e9b"
-cursor_fg = "#b9b6b0"
+cursor_fg = "#2f1e2e"
 
 selection_bg = "#a39e9b"
 selection_fg = "#2f1e2e"

--- a/themes/wezterm/base16-pasque.toml
+++ b/themes/wezterm/base16-pasque.toml
@@ -4,9 +4,9 @@
 background = "#271c3a"
 foreground = "#dedcdf"
 
-cursor_bg = "#100323"
+cursor_bg = "#dedcdf"
 cursor_border = "#dedcdf"
-cursor_fg = "#edeaef"
+cursor_fg = "#271c3a"
 
 selection_bg = "#dedcdf"
 selection_fg = "#271c3a"

--- a/themes/wezterm/base16-penumbra-dark-contrast-plus-plus.toml
+++ b/themes/wezterm/base16-penumbra-dark-contrast-plus-plus.toml
@@ -4,9 +4,9 @@
 background = "#0d0f13"
 foreground = "#dedede"
 
-cursor_bg = "#181b1f"
+cursor_bg = "#dedede"
 cursor_border = "#dedede"
-cursor_fg = "#fff7ed"
+cursor_fg = "#0d0f13"
 
 selection_bg = "#dedede"
 selection_fg = "#0d0f13"

--- a/themes/wezterm/base16-penumbra-dark-contrast-plus.toml
+++ b/themes/wezterm/base16-penumbra-dark-contrast-plus.toml
@@ -4,9 +4,9 @@
 background = "#181b1f"
 foreground = "#cecece"
 
-cursor_bg = "#24272b"
+cursor_bg = "#cecece"
 cursor_border = "#cecece"
-cursor_fg = "#fff7ed"
+cursor_fg = "#181b1f"
 
 selection_bg = "#cecece"
 selection_fg = "#181b1f"

--- a/themes/wezterm/base16-penumbra-dark.toml
+++ b/themes/wezterm/base16-penumbra-dark.toml
@@ -4,9 +4,9 @@
 background = "#24272b"
 foreground = "#bebebe"
 
-cursor_bg = "#303338"
+cursor_bg = "#bebebe"
 cursor_border = "#bebebe"
-cursor_fg = "#fff7ed"
+cursor_fg = "#24272b"
 
 selection_bg = "#bebebe"
 selection_fg = "#24272b"

--- a/themes/wezterm/base16-penumbra-light-contrast-plus-plus.toml
+++ b/themes/wezterm/base16-penumbra-light-contrast-plus-plus.toml
@@ -4,9 +4,9 @@
 background = "#fffdfb"
 foreground = "#636363"
 
-cursor_bg = "#fff7ed"
+cursor_bg = "#636363"
 cursor_border = "#636363"
-cursor_fg = "#181b1f"
+cursor_fg = "#fffdfb"
 
 selection_bg = "#636363"
 selection_fg = "#fffdfb"

--- a/themes/wezterm/base16-penumbra-light-contrast-plus.toml
+++ b/themes/wezterm/base16-penumbra-light-contrast-plus.toml
@@ -4,9 +4,9 @@
 background = "#fffdfb"
 foreground = "#636363"
 
-cursor_bg = "#fff7ed"
+cursor_bg = "#636363"
 cursor_border = "#636363"
-cursor_fg = "#24272b"
+cursor_fg = "#fffdfb"
 
 selection_bg = "#636363"
 selection_fg = "#fffdfb"

--- a/themes/wezterm/base16-penumbra-light.toml
+++ b/themes/wezterm/base16-penumbra-light.toml
@@ -4,9 +4,9 @@
 background = "#fffdfb"
 foreground = "#636363"
 
-cursor_bg = "#fff7ed"
+cursor_bg = "#636363"
 cursor_border = "#636363"
-cursor_fg = "#303338"
+cursor_fg = "#fffdfb"
 
 selection_bg = "#636363"
 selection_fg = "#fffdfb"

--- a/themes/wezterm/base16-phd.toml
+++ b/themes/wezterm/base16-phd.toml
@@ -4,9 +4,9 @@
 background = "#061229"
 foreground = "#b8bbc2"
 
-cursor_bg = "#2a3448"
+cursor_bg = "#b8bbc2"
 cursor_border = "#b8bbc2"
-cursor_fg = "#dbdde0"
+cursor_fg = "#061229"
 
 selection_bg = "#b8bbc2"
 selection_fg = "#061229"

--- a/themes/wezterm/base16-pico.toml
+++ b/themes/wezterm/base16-pico.toml
@@ -4,9 +4,9 @@
 background = "#000000"
 foreground = "#5f574f"
 
-cursor_bg = "#1d2b53"
+cursor_bg = "#5f574f"
 cursor_border = "#5f574f"
-cursor_fg = "#c2c3c7"
+cursor_fg = "#000000"
 
 selection_bg = "#5f574f"
 selection_fg = "#000000"

--- a/themes/wezterm/base16-pinky.toml
+++ b/themes/wezterm/base16-pinky.toml
@@ -4,9 +4,9 @@
 background = "#171517"
 foreground = "#f5f5f5"
 
-cursor_bg = "#1b181b"
+cursor_bg = "#f5f5f5"
 cursor_border = "#f5f5f5"
-cursor_fg = "#ffffff"
+cursor_fg = "#171517"
 
 selection_bg = "#f5f5f5"
 selection_fg = "#171517"

--- a/themes/wezterm/base16-pop.toml
+++ b/themes/wezterm/base16-pop.toml
@@ -4,9 +4,9 @@
 background = "#000000"
 foreground = "#d0d0d0"
 
-cursor_bg = "#202020"
+cursor_bg = "#d0d0d0"
 cursor_border = "#d0d0d0"
-cursor_fg = "#e0e0e0"
+cursor_fg = "#000000"
 
 selection_bg = "#d0d0d0"
 selection_fg = "#000000"

--- a/themes/wezterm/base16-porple.toml
+++ b/themes/wezterm/base16-porple.toml
@@ -4,9 +4,9 @@
 background = "#292c36"
 foreground = "#d8d8d8"
 
-cursor_bg = "#333344"
+cursor_bg = "#d8d8d8"
 cursor_border = "#d8d8d8"
-cursor_fg = "#e8e8e8"
+cursor_fg = "#292c36"
 
 selection_bg = "#d8d8d8"
 selection_fg = "#292c36"

--- a/themes/wezterm/base16-precious-dark-eleven.toml
+++ b/themes/wezterm/base16-precious-dark-eleven.toml
@@ -4,9 +4,9 @@
 background = "#1c1e20"
 foreground = "#b8b7b6"
 
-cursor_bg = "#292b2d"
+cursor_bg = "#b8b7b6"
 cursor_border = "#b8b7b6"
-cursor_fg = "#b8b7b6"
+cursor_fg = "#1c1e20"
 
 selection_bg = "#b8b7b6"
 selection_fg = "#1c1e20"

--- a/themes/wezterm/base16-precious-dark-fifteen.toml
+++ b/themes/wezterm/base16-precious-dark-fifteen.toml
@@ -4,9 +4,9 @@
 background = "#23262b"
 foreground = "#bab9b6"
 
-cursor_bg = "#303337"
+cursor_bg = "#bab9b6"
 cursor_border = "#bab9b6"
-cursor_fg = "#bab9b6"
+cursor_fg = "#23262b"
 
 selection_bg = "#bab9b6"
 selection_fg = "#23262b"

--- a/themes/wezterm/base16-precious-light-warm.toml
+++ b/themes/wezterm/base16-precious-light-warm.toml
@@ -4,9 +4,9 @@
 background = "#fff5e5"
 foreground = "#4e5359"
 
-cursor_bg = "#ece4d6"
+cursor_bg = "#4e5359"
 cursor_border = "#4e5359"
-cursor_fg = "#4e5359"
+cursor_fg = "#fff5e5"
 
 selection_bg = "#4e5359"
 selection_fg = "#fff5e5"

--- a/themes/wezterm/base16-precious-light-white.toml
+++ b/themes/wezterm/base16-precious-light-white.toml
@@ -4,9 +4,9 @@
 background = "#ffffff"
 foreground = "#555555"
 
-cursor_bg = "#ededed"
+cursor_bg = "#555555"
 cursor_border = "#555555"
-cursor_fg = "#555555"
+cursor_fg = "#ffffff"
 
 selection_bg = "#555555"
 selection_fg = "#ffffff"

--- a/themes/wezterm/base16-primer-dark-dimmed.toml
+++ b/themes/wezterm/base16-primer-dark-dimmed.toml
@@ -4,9 +4,9 @@
 background = "#1c2128"
 foreground = "#909dab"
 
-cursor_bg = "#373e47"
+cursor_bg = "#909dab"
 cursor_border = "#909dab"
-cursor_fg = "#adbac7"
+cursor_fg = "#1c2128"
 
 selection_bg = "#909dab"
 selection_fg = "#1c2128"

--- a/themes/wezterm/base16-primer-dark.toml
+++ b/themes/wezterm/base16-primer-dark.toml
@@ -4,9 +4,9 @@
 background = "#010409"
 foreground = "#b1bac4"
 
-cursor_bg = "#21262d"
+cursor_bg = "#b1bac4"
 cursor_border = "#b1bac4"
-cursor_fg = "#c9d1d9"
+cursor_fg = "#010409"
 
 selection_bg = "#b1bac4"
 selection_fg = "#010409"

--- a/themes/wezterm/base16-primer-light.toml
+++ b/themes/wezterm/base16-primer-light.toml
@@ -4,9 +4,9 @@
 background = "#fafbfc"
 foreground = "#2f363d"
 
-cursor_bg = "#e1e4e8"
+cursor_bg = "#2f363d"
 cursor_border = "#2f363d"
-cursor_fg = "#24292e"
+cursor_fg = "#fafbfc"
 
 selection_bg = "#2f363d"
 selection_fg = "#fafbfc"

--- a/themes/wezterm/base16-purpledream.toml
+++ b/themes/wezterm/base16-purpledream.toml
@@ -4,9 +4,9 @@
 background = "#100510"
 foreground = "#ddd0dd"
 
-cursor_bg = "#302030"
+cursor_bg = "#ddd0dd"
 cursor_border = "#ddd0dd"
-cursor_fg = "#eee0ee"
+cursor_fg = "#100510"
 
 selection_bg = "#ddd0dd"
 selection_fg = "#100510"

--- a/themes/wezterm/base16-qualia.toml
+++ b/themes/wezterm/base16-qualia.toml
@@ -4,9 +4,9 @@
 background = "#101010"
 foreground = "#c0c0c0"
 
-cursor_bg = "#454545"
+cursor_bg = "#c0c0c0"
 cursor_border = "#c0c0c0"
-cursor_fg = "#c0c0c0"
+cursor_fg = "#101010"
 
 selection_bg = "#c0c0c0"
 selection_fg = "#101010"

--- a/themes/wezterm/base16-railscasts.toml
+++ b/themes/wezterm/base16-railscasts.toml
@@ -4,9 +4,9 @@
 background = "#2b2b2b"
 foreground = "#e6e1dc"
 
-cursor_bg = "#272935"
+cursor_bg = "#e6e1dc"
 cursor_border = "#e6e1dc"
-cursor_fg = "#f4f1ed"
+cursor_fg = "#2b2b2b"
 
 selection_bg = "#e6e1dc"
 selection_fg = "#2b2b2b"

--- a/themes/wezterm/base16-rebecca.toml
+++ b/themes/wezterm/base16-rebecca.toml
@@ -4,9 +4,9 @@
 background = "#292a44"
 foreground = "#f1eff8"
 
-cursor_bg = "#663399"
+cursor_bg = "#f1eff8"
 cursor_border = "#f1eff8"
-cursor_fg = "#ccccff"
+cursor_fg = "#292a44"
 
 selection_bg = "#f1eff8"
 selection_fg = "#292a44"

--- a/themes/wezterm/base16-rose-pine-dawn.toml
+++ b/themes/wezterm/base16-rose-pine-dawn.toml
@@ -4,9 +4,9 @@
 background = "#faf4ed"
 foreground = "#575279"
 
-cursor_bg = "#fffaf3"
+cursor_bg = "#575279"
 cursor_border = "#575279"
-cursor_fg = "#575279"
+cursor_fg = "#faf4ed"
 
 selection_bg = "#575279"
 selection_fg = "#faf4ed"

--- a/themes/wezterm/base16-rose-pine-moon.toml
+++ b/themes/wezterm/base16-rose-pine-moon.toml
@@ -4,9 +4,9 @@
 background = "#232136"
 foreground = "#e0def4"
 
-cursor_bg = "#2a273f"
+cursor_bg = "#e0def4"
 cursor_border = "#e0def4"
-cursor_fg = "#e0def4"
+cursor_fg = "#232136"
 
 selection_bg = "#e0def4"
 selection_fg = "#232136"

--- a/themes/wezterm/base16-rose-pine.toml
+++ b/themes/wezterm/base16-rose-pine.toml
@@ -4,9 +4,9 @@
 background = "#191724"
 foreground = "#e0def4"
 
-cursor_bg = "#1f1d2e"
+cursor_bg = "#e0def4"
 cursor_border = "#e0def4"
-cursor_fg = "#e0def4"
+cursor_fg = "#191724"
 
 selection_bg = "#e0def4"
 selection_fg = "#191724"

--- a/themes/wezterm/base16-saga.toml
+++ b/themes/wezterm/base16-saga.toml
@@ -4,9 +4,9 @@
 background = "#05080a"
 foreground = "#dce2f7"
 
-cursor_bg = "#0a1014"
+cursor_bg = "#dce2f7"
 cursor_border = "#dce2f7"
-cursor_fg = "#f8eae7"
+cursor_fg = "#05080a"
 
 selection_bg = "#dce2f7"
 selection_fg = "#05080a"

--- a/themes/wezterm/base16-sagelight.toml
+++ b/themes/wezterm/base16-sagelight.toml
@@ -4,9 +4,9 @@
 background = "#f8f8f8"
 foreground = "#383838"
 
-cursor_bg = "#e8e8e8"
+cursor_bg = "#383838"
 cursor_border = "#383838"
-cursor_fg = "#282828"
+cursor_fg = "#f8f8f8"
 
 selection_bg = "#383838"
 selection_fg = "#f8f8f8"

--- a/themes/wezterm/base16-sakura.toml
+++ b/themes/wezterm/base16-sakura.toml
@@ -4,9 +4,9 @@
 background = "#feedf3"
 foreground = "#564448"
 
-cursor_bg = "#f8e2e7"
+cursor_bg = "#564448"
 cursor_border = "#564448"
-cursor_fg = "#42383a"
+cursor_fg = "#feedf3"
 
 selection_bg = "#564448"
 selection_fg = "#feedf3"

--- a/themes/wezterm/base16-sandcastle.toml
+++ b/themes/wezterm/base16-sandcastle.toml
@@ -4,9 +4,9 @@
 background = "#282c34"
 foreground = "#a89984"
 
-cursor_bg = "#2c323b"
+cursor_bg = "#a89984"
 cursor_border = "#a89984"
-cursor_fg = "#d5c4a1"
+cursor_fg = "#282c34"
 
 selection_bg = "#a89984"
 selection_fg = "#282c34"

--- a/themes/wezterm/base16-selenized-black.toml
+++ b/themes/wezterm/base16-selenized-black.toml
@@ -4,9 +4,9 @@
 background = "#181818"
 foreground = "#b9b9b9"
 
-cursor_bg = "#252525"
+cursor_bg = "#b9b9b9"
 cursor_border = "#b9b9b9"
-cursor_fg = "#dedede"
+cursor_fg = "#181818"
 
 selection_bg = "#b9b9b9"
 selection_fg = "#181818"

--- a/themes/wezterm/base16-selenized-dark.toml
+++ b/themes/wezterm/base16-selenized-dark.toml
@@ -4,9 +4,9 @@
 background = "#103c48"
 foreground = "#adbcbc"
 
-cursor_bg = "#184956"
+cursor_bg = "#adbcbc"
 cursor_border = "#adbcbc"
-cursor_fg = "#cad8d9"
+cursor_fg = "#103c48"
 
 selection_bg = "#adbcbc"
 selection_fg = "#103c48"

--- a/themes/wezterm/base16-selenized-light.toml
+++ b/themes/wezterm/base16-selenized-light.toml
@@ -4,9 +4,9 @@
 background = "#fbf3db"
 foreground = "#53676d"
 
-cursor_bg = "#ece3cc"
+cursor_bg = "#53676d"
 cursor_border = "#53676d"
-cursor_fg = "#3a4d53"
+cursor_fg = "#fbf3db"
 
 selection_bg = "#53676d"
 selection_fg = "#fbf3db"

--- a/themes/wezterm/base16-selenized-white.toml
+++ b/themes/wezterm/base16-selenized-white.toml
@@ -4,9 +4,9 @@
 background = "#ffffff"
 foreground = "#474747"
 
-cursor_bg = "#ebebeb"
+cursor_bg = "#474747"
 cursor_border = "#474747"
-cursor_fg = "#282828"
+cursor_fg = "#ffffff"
 
 selection_bg = "#474747"
 selection_fg = "#ffffff"

--- a/themes/wezterm/base16-seti.toml
+++ b/themes/wezterm/base16-seti.toml
@@ -4,9 +4,9 @@
 background = "#151718"
 foreground = "#d6d6d6"
 
-cursor_bg = "#282a2b"
+cursor_bg = "#d6d6d6"
 cursor_border = "#d6d6d6"
-cursor_fg = "#eeeeee"
+cursor_fg = "#151718"
 
 selection_bg = "#d6d6d6"
 selection_fg = "#151718"

--- a/themes/wezterm/base16-shades-of-purple.toml
+++ b/themes/wezterm/base16-shades-of-purple.toml
@@ -4,9 +4,9 @@
 background = "#1e1e3f"
 foreground = "#c7c7c7"
 
-cursor_bg = "#43d426"
+cursor_bg = "#c7c7c7"
 cursor_border = "#c7c7c7"
-cursor_fg = "#ff77ff"
+cursor_fg = "#1e1e3f"
 
 selection_bg = "#c7c7c7"
 selection_fg = "#1e1e3f"

--- a/themes/wezterm/base16-shadesmear-dark.toml
+++ b/themes/wezterm/base16-shadesmear-dark.toml
@@ -4,9 +4,9 @@
 background = "#232323"
 foreground = "#dbdbdb"
 
-cursor_bg = "#1c1c1c"
+cursor_bg = "#dbdbdb"
 cursor_border = "#dbdbdb"
-cursor_fg = "#e4e4e4"
+cursor_fg = "#232323"
 
 selection_bg = "#dbdbdb"
 selection_fg = "#232323"

--- a/themes/wezterm/base16-shadesmear-light.toml
+++ b/themes/wezterm/base16-shadesmear-light.toml
@@ -4,9 +4,9 @@
 background = "#dbdbdb"
 foreground = "#232323"
 
-cursor_bg = "#e4e4e4"
+cursor_bg = "#232323"
 cursor_border = "#232323"
-cursor_fg = "#1c1c1c"
+cursor_fg = "#dbdbdb"
 
 selection_bg = "#232323"
 selection_fg = "#dbdbdb"

--- a/themes/wezterm/base16-shapeshifter.toml
+++ b/themes/wezterm/base16-shapeshifter.toml
@@ -4,9 +4,9 @@
 background = "#f9f9f9"
 foreground = "#102015"
 
-cursor_bg = "#e0e0e0"
+cursor_bg = "#102015"
 cursor_border = "#102015"
-cursor_fg = "#040404"
+cursor_fg = "#f9f9f9"
 
 selection_bg = "#102015"
 selection_fg = "#f9f9f9"

--- a/themes/wezterm/base16-silk-dark.toml
+++ b/themes/wezterm/base16-silk-dark.toml
@@ -4,9 +4,9 @@
 background = "#0e3c46"
 foreground = "#c7dbdd"
 
-cursor_bg = "#1d494e"
+cursor_bg = "#c7dbdd"
 cursor_border = "#c7dbdd"
-cursor_fg = "#cbf2f7"
+cursor_fg = "#0e3c46"
 
 selection_bg = "#c7dbdd"
 selection_fg = "#0e3c46"

--- a/themes/wezterm/base16-silk-light.toml
+++ b/themes/wezterm/base16-silk-light.toml
@@ -4,9 +4,9 @@
 background = "#e9f1ef"
 foreground = "#385156"
 
-cursor_bg = "#ccd4d3"
+cursor_bg = "#385156"
 cursor_border = "#385156"
-cursor_fg = "#0e3c46"
+cursor_fg = "#e9f1ef"
 
 selection_bg = "#385156"
 selection_fg = "#e9f1ef"

--- a/themes/wezterm/base16-snazzy.toml
+++ b/themes/wezterm/base16-snazzy.toml
@@ -4,9 +4,9 @@
 background = "#282a36"
 foreground = "#e2e4e5"
 
-cursor_bg = "#34353e"
+cursor_bg = "#e2e4e5"
 cursor_border = "#e2e4e5"
-cursor_fg = "#eff0eb"
+cursor_fg = "#282a36"
 
 selection_bg = "#e2e4e5"
 selection_fg = "#282a36"

--- a/themes/wezterm/base16-solarflare-light.toml
+++ b/themes/wezterm/base16-solarflare-light.toml
@@ -4,9 +4,9 @@
 background = "#f5f7fa"
 foreground = "#586875"
 
-cursor_bg = "#e8e9ed"
+cursor_bg = "#586875"
 cursor_border = "#586875"
-cursor_fg = "#222e38"
+cursor_fg = "#f5f7fa"
 
 selection_bg = "#586875"
 selection_fg = "#f5f7fa"

--- a/themes/wezterm/base16-solarflare.toml
+++ b/themes/wezterm/base16-solarflare.toml
@@ -4,9 +4,9 @@
 background = "#18262f"
 foreground = "#a6afb8"
 
-cursor_bg = "#222e38"
+cursor_bg = "#a6afb8"
 cursor_border = "#a6afb8"
-cursor_fg = "#e8e9ed"
+cursor_fg = "#18262f"
 
 selection_bg = "#a6afb8"
 selection_fg = "#18262f"

--- a/themes/wezterm/base16-solarized-dark.toml
+++ b/themes/wezterm/base16-solarized-dark.toml
@@ -4,9 +4,9 @@
 background = "#002b36"
 foreground = "#93a1a1"
 
-cursor_bg = "#073642"
+cursor_bg = "#93a1a1"
 cursor_border = "#93a1a1"
-cursor_fg = "#eee8d5"
+cursor_fg = "#002b36"
 
 selection_bg = "#93a1a1"
 selection_fg = "#002b36"

--- a/themes/wezterm/base16-solarized-light.toml
+++ b/themes/wezterm/base16-solarized-light.toml
@@ -4,9 +4,9 @@
 background = "#fdf6e3"
 foreground = "#586e75"
 
-cursor_bg = "#eee8d5"
+cursor_bg = "#586e75"
 cursor_border = "#586e75"
-cursor_fg = "#073642"
+cursor_fg = "#fdf6e3"
 
 selection_bg = "#586e75"
 selection_fg = "#fdf6e3"

--- a/themes/wezterm/base16-spaceduck.toml
+++ b/themes/wezterm/base16-spaceduck.toml
@@ -4,9 +4,9 @@
 background = "#16172d"
 foreground = "#ecf0c1"
 
-cursor_bg = "#1b1c36"
+cursor_bg = "#ecf0c1"
 cursor_border = "#ecf0c1"
-cursor_fg = "#c1c3cc"
+cursor_fg = "#16172d"
 
 selection_bg = "#ecf0c1"
 selection_fg = "#16172d"

--- a/themes/wezterm/base16-spacemacs.toml
+++ b/themes/wezterm/base16-spacemacs.toml
@@ -4,9 +4,9 @@
 background = "#1f2022"
 foreground = "#a3a3a3"
 
-cursor_bg = "#282828"
+cursor_bg = "#a3a3a3"
 cursor_border = "#a3a3a3"
-cursor_fg = "#e8e8e8"
+cursor_fg = "#1f2022"
 
 selection_bg = "#a3a3a3"
 selection_fg = "#1f2022"

--- a/themes/wezterm/base16-sparky.toml
+++ b/themes/wezterm/base16-sparky.toml
@@ -4,9 +4,9 @@
 background = "#072b31"
 foreground = "#f4f5f0"
 
-cursor_bg = "#00313c"
+cursor_bg = "#f4f5f0"
 cursor_border = "#f4f5f0"
-cursor_fg = "#f5f5f1"
+cursor_fg = "#072b31"
 
 selection_bg = "#f4f5f0"
 selection_fg = "#072b31"

--- a/themes/wezterm/base16-standardized-dark.toml
+++ b/themes/wezterm/base16-standardized-dark.toml
@@ -4,9 +4,9 @@
 background = "#222222"
 foreground = "#c0c0c0"
 
-cursor_bg = "#303030"
+cursor_bg = "#c0c0c0"
 cursor_border = "#c0c0c0"
-cursor_fg = "#e0e0e0"
+cursor_fg = "#222222"
 
 selection_bg = "#c0c0c0"
 selection_fg = "#222222"

--- a/themes/wezterm/base16-standardized-light.toml
+++ b/themes/wezterm/base16-standardized-light.toml
@@ -4,9 +4,9 @@
 background = "#ffffff"
 foreground = "#444444"
 
-cursor_bg = "#eeeeee"
+cursor_bg = "#444444"
 cursor_border = "#444444"
-cursor_fg = "#333333"
+cursor_fg = "#ffffff"
 
 selection_bg = "#444444"
 selection_fg = "#ffffff"

--- a/themes/wezterm/base16-stella.toml
+++ b/themes/wezterm/base16-stella.toml
@@ -4,9 +4,9 @@
 background = "#2b213c"
 foreground = "#998bad"
 
-cursor_bg = "#362b48"
+cursor_bg = "#998bad"
 cursor_border = "#998bad"
-cursor_fg = "#b4a5c8"
+cursor_fg = "#2b213c"
 
 selection_bg = "#998bad"
 selection_fg = "#2b213c"

--- a/themes/wezterm/base16-still-alive.toml
+++ b/themes/wezterm/base16-still-alive.toml
@@ -4,9 +4,9 @@
 background = "#f0f0f0"
 foreground = "#d80000"
 
-cursor_bg = "#f0d848"
+cursor_bg = "#d80000"
 cursor_border = "#d80000"
-cursor_fg = "#489000"
+cursor_fg = "#f0f0f0"
 
 selection_bg = "#d80000"
 selection_fg = "#f0f0f0"

--- a/themes/wezterm/base16-summercamp.toml
+++ b/themes/wezterm/base16-summercamp.toml
@@ -4,9 +4,9 @@
 background = "#1c1810"
 foreground = "#736e55"
 
-cursor_bg = "#2a261c"
+cursor_bg = "#736e55"
 cursor_border = "#736e55"
-cursor_fg = "#bab696"
+cursor_fg = "#1c1810"
 
 selection_bg = "#736e55"
 selection_fg = "#1c1810"

--- a/themes/wezterm/base16-summerfruit-dark.toml
+++ b/themes/wezterm/base16-summerfruit-dark.toml
@@ -4,9 +4,9 @@
 background = "#151515"
 foreground = "#d0d0d0"
 
-cursor_bg = "#202020"
+cursor_bg = "#d0d0d0"
 cursor_border = "#d0d0d0"
-cursor_fg = "#e0e0e0"
+cursor_fg = "#151515"
 
 selection_bg = "#d0d0d0"
 selection_fg = "#151515"

--- a/themes/wezterm/base16-summerfruit-light.toml
+++ b/themes/wezterm/base16-summerfruit-light.toml
@@ -4,9 +4,9 @@
 background = "#ffffff"
 foreground = "#101010"
 
-cursor_bg = "#e0e0e0"
+cursor_bg = "#101010"
 cursor_border = "#101010"
-cursor_fg = "#151515"
+cursor_fg = "#ffffff"
 
 selection_bg = "#101010"
 selection_fg = "#ffffff"

--- a/themes/wezterm/base16-synth-midnight-dark.toml
+++ b/themes/wezterm/base16-synth-midnight-dark.toml
@@ -4,9 +4,9 @@
 background = "#050608"
 foreground = "#c1c3c4"
 
-cursor_bg = "#1a1b1c"
+cursor_bg = "#c1c3c4"
 cursor_border = "#c1c3c4"
-cursor_fg = "#cfd1d2"
+cursor_fg = "#050608"
 
 selection_bg = "#c1c3c4"
 selection_fg = "#050608"

--- a/themes/wezterm/base16-synth-midnight-light.toml
+++ b/themes/wezterm/base16-synth-midnight-light.toml
@@ -4,9 +4,9 @@
 background = "#dddfe0"
 foreground = "#28292a"
 
-cursor_bg = "#cfd1d2"
+cursor_bg = "#28292a"
 cursor_border = "#28292a"
-cursor_fg = "#1a1b1c"
+cursor_fg = "#dddfe0"
 
 selection_bg = "#28292a"
 selection_fg = "#dddfe0"

--- a/themes/wezterm/base16-tango.toml
+++ b/themes/wezterm/base16-tango.toml
@@ -4,9 +4,9 @@
 background = "#2e3436"
 foreground = "#d3d7cf"
 
-cursor_bg = "#8ae234"
+cursor_bg = "#d3d7cf"
 cursor_border = "#d3d7cf"
-cursor_fg = "#ad7fa8"
+cursor_fg = "#2e3436"
 
 selection_bg = "#d3d7cf"
 selection_fg = "#2e3436"

--- a/themes/wezterm/base16-tarot.toml
+++ b/themes/wezterm/base16-tarot.toml
@@ -4,9 +4,9 @@
 background = "#0e091d"
 foreground = "#aa556f"
 
-cursor_bg = "#2a153c"
+cursor_bg = "#aa556f"
 cursor_border = "#aa556f"
-cursor_fg = "#c4686d"
+cursor_fg = "#0e091d"
 
 selection_bg = "#aa556f"
 selection_fg = "#0e091d"

--- a/themes/wezterm/base16-tender.toml
+++ b/themes/wezterm/base16-tender.toml
@@ -4,9 +4,9 @@
 background = "#282828"
 foreground = "#eeeeee"
 
-cursor_bg = "#383838"
+cursor_bg = "#eeeeee"
 cursor_border = "#eeeeee"
-cursor_fg = "#e8e8e8"
+cursor_fg = "#282828"
 
 selection_bg = "#eeeeee"
 selection_fg = "#282828"

--- a/themes/wezterm/base16-terracotta-dark.toml
+++ b/themes/wezterm/base16-terracotta-dark.toml
@@ -4,9 +4,9 @@
 background = "#241d1a"
 foreground = "#b8a59d"
 
-cursor_bg = "#362b27"
+cursor_bg = "#b8a59d"
 cursor_border = "#b8a59d"
-cursor_fg = "#cabbb5"
+cursor_fg = "#241d1a"
 
 selection_bg = "#b8a59d"
 selection_fg = "#241d1a"

--- a/themes/wezterm/base16-terracotta.toml
+++ b/themes/wezterm/base16-terracotta.toml
@@ -4,9 +4,9 @@
 background = "#efeae8"
 foreground = "#473731"
 
-cursor_bg = "#dfd6d1"
+cursor_bg = "#473731"
 cursor_border = "#473731"
-cursor_fg = "#352a25"
+cursor_fg = "#efeae8"
 
 selection_bg = "#473731"
 selection_fg = "#efeae8"

--- a/themes/wezterm/base16-tokyo-city-dark.toml
+++ b/themes/wezterm/base16-tokyo-city-dark.toml
@@ -4,9 +4,9 @@
 background = "#171d23"
 foreground = "#d8e2ec"
 
-cursor_bg = "#1d252c"
+cursor_bg = "#d8e2ec"
 cursor_border = "#d8e2ec"
-cursor_fg = "#f6f6f8"
+cursor_fg = "#171d23"
 
 selection_bg = "#d8e2ec"
 selection_fg = "#171d23"

--- a/themes/wezterm/base16-tokyo-city-light.toml
+++ b/themes/wezterm/base16-tokyo-city-light.toml
@@ -4,9 +4,9 @@
 background = "#fbfbfd"
 foreground = "#343b59"
 
-cursor_bg = "#f6f6f8"
+cursor_bg = "#343b59"
 cursor_border = "#343b59"
-cursor_fg = "#1d252c"
+cursor_fg = "#fbfbfd"
 
 selection_bg = "#343b59"
 selection_fg = "#fbfbfd"

--- a/themes/wezterm/base16-tokyo-city-terminal-dark.toml
+++ b/themes/wezterm/base16-tokyo-city-terminal-dark.toml
@@ -4,9 +4,9 @@
 background = "#171d23"
 foreground = "#d8e2ec"
 
-cursor_bg = "#1d252c"
+cursor_bg = "#d8e2ec"
 cursor_border = "#d8e2ec"
-cursor_fg = "#f6f6f8"
+cursor_fg = "#171d23"
 
 selection_bg = "#d8e2ec"
 selection_fg = "#171d23"

--- a/themes/wezterm/base16-tokyo-city-terminal-light.toml
+++ b/themes/wezterm/base16-tokyo-city-terminal-light.toml
@@ -4,9 +4,9 @@
 background = "#fbfbfd"
 foreground = "#28323a"
 
-cursor_bg = "#f6f6f8"
+cursor_bg = "#28323a"
 cursor_border = "#28323a"
-cursor_fg = "#1d252c"
+cursor_fg = "#fbfbfd"
 
 selection_bg = "#28323a"
 selection_fg = "#fbfbfd"

--- a/themes/wezterm/base16-tokyo-night-dark.toml
+++ b/themes/wezterm/base16-tokyo-night-dark.toml
@@ -4,9 +4,9 @@
 background = "#1a1b26"
 foreground = "#a9b1d6"
 
-cursor_bg = "#16161e"
+cursor_bg = "#a9b1d6"
 cursor_border = "#a9b1d6"
-cursor_fg = "#cbccd1"
+cursor_fg = "#1a1b26"
 
 selection_bg = "#a9b1d6"
 selection_fg = "#1a1b26"

--- a/themes/wezterm/base16-tokyo-night-light.toml
+++ b/themes/wezterm/base16-tokyo-night-light.toml
@@ -4,9 +4,9 @@
 background = "#d5d6db"
 foreground = "#343b59"
 
-cursor_bg = "#cbccd1"
+cursor_bg = "#343b59"
 cursor_border = "#343b59"
-cursor_fg = "#1a1b26"
+cursor_fg = "#d5d6db"
 
 selection_bg = "#343b59"
 selection_fg = "#d5d6db"

--- a/themes/wezterm/base16-tokyo-night-moon.toml
+++ b/themes/wezterm/base16-tokyo-night-moon.toml
@@ -4,9 +4,9 @@
 background = "#222436"
 foreground = "#3b4261"
 
-cursor_bg = "#1e2030"
+cursor_bg = "#3b4261"
 cursor_border = "#3b4261"
-cursor_fg = "#828bb8"
+cursor_fg = "#222436"
 
 selection_bg = "#3b4261"
 selection_fg = "#222436"

--- a/themes/wezterm/base16-tokyo-night-storm.toml
+++ b/themes/wezterm/base16-tokyo-night-storm.toml
@@ -4,9 +4,9 @@
 background = "#24283b"
 foreground = "#a9b1d6"
 
-cursor_bg = "#16161e"
+cursor_bg = "#a9b1d6"
 cursor_border = "#a9b1d6"
-cursor_fg = "#cbccd1"
+cursor_fg = "#24283b"
 
 selection_bg = "#a9b1d6"
 selection_fg = "#24283b"

--- a/themes/wezterm/base16-tokyo-night-terminal-dark.toml
+++ b/themes/wezterm/base16-tokyo-night-terminal-dark.toml
@@ -4,9 +4,9 @@
 background = "#16161e"
 foreground = "#787c99"
 
-cursor_bg = "#1a1b26"
+cursor_bg = "#787c99"
 cursor_border = "#787c99"
-cursor_fg = "#cbccd1"
+cursor_fg = "#16161e"
 
 selection_bg = "#787c99"
 selection_fg = "#16161e"

--- a/themes/wezterm/base16-tokyo-night-terminal-light.toml
+++ b/themes/wezterm/base16-tokyo-night-terminal-light.toml
@@ -4,9 +4,9 @@
 background = "#d5d6db"
 foreground = "#4c505e"
 
-cursor_bg = "#cbccd1"
+cursor_bg = "#4c505e"
 cursor_border = "#4c505e"
-cursor_fg = "#1a1b26"
+cursor_fg = "#d5d6db"
 
 selection_bg = "#4c505e"
 selection_fg = "#d5d6db"

--- a/themes/wezterm/base16-tokyo-night-terminal-storm.toml
+++ b/themes/wezterm/base16-tokyo-night-terminal-storm.toml
@@ -4,9 +4,9 @@
 background = "#24283b"
 foreground = "#787c99"
 
-cursor_bg = "#1a1b26"
+cursor_bg = "#787c99"
 cursor_border = "#787c99"
-cursor_fg = "#cbccd1"
+cursor_fg = "#24283b"
 
 selection_bg = "#787c99"
 selection_fg = "#24283b"

--- a/themes/wezterm/base16-tokyodark-terminal.toml
+++ b/themes/wezterm/base16-tokyodark-terminal.toml
@@ -4,9 +4,9 @@
 background = "#11121d"
 foreground = "#a0a8cd"
 
-cursor_bg = "#1a1b2a"
+cursor_bg = "#a0a8cd"
 cursor_border = "#a0a8cd"
-cursor_fg = "#a0a8cd"
+cursor_fg = "#11121d"
 
 selection_bg = "#a0a8cd"
 selection_fg = "#11121d"

--- a/themes/wezterm/base16-tokyodark.toml
+++ b/themes/wezterm/base16-tokyodark.toml
@@ -4,9 +4,9 @@
 background = "#11121d"
 foreground = "#a0a8cd"
 
-cursor_bg = "#212234"
+cursor_bg = "#a0a8cd"
 cursor_border = "#a0a8cd"
-cursor_fg = "#abb2bf"
+cursor_fg = "#11121d"
 
 selection_bg = "#a0a8cd"
 selection_fg = "#11121d"

--- a/themes/wezterm/base16-tomorrow-night-eighties.toml
+++ b/themes/wezterm/base16-tomorrow-night-eighties.toml
@@ -4,9 +4,9 @@
 background = "#2d2d2d"
 foreground = "#cccccc"
 
-cursor_bg = "#393939"
+cursor_bg = "#cccccc"
 cursor_border = "#cccccc"
-cursor_fg = "#e0e0e0"
+cursor_fg = "#2d2d2d"
 
 selection_bg = "#cccccc"
 selection_fg = "#2d2d2d"

--- a/themes/wezterm/base16-tomorrow-night.toml
+++ b/themes/wezterm/base16-tomorrow-night.toml
@@ -4,9 +4,9 @@
 background = "#1d1f21"
 foreground = "#c5c8c6"
 
-cursor_bg = "#282a2e"
+cursor_bg = "#c5c8c6"
 cursor_border = "#c5c8c6"
-cursor_fg = "#e0e0e0"
+cursor_fg = "#1d1f21"
 
 selection_bg = "#c5c8c6"
 selection_fg = "#1d1f21"

--- a/themes/wezterm/base16-tomorrow.toml
+++ b/themes/wezterm/base16-tomorrow.toml
@@ -4,9 +4,9 @@
 background = "#ffffff"
 foreground = "#4d4d4c"
 
-cursor_bg = "#e0e0e0"
+cursor_bg = "#4d4d4c"
 cursor_border = "#4d4d4c"
-cursor_fg = "#282a2e"
+cursor_fg = "#ffffff"
 
 selection_bg = "#4d4d4c"
 selection_fg = "#ffffff"

--- a/themes/wezterm/base16-tube.toml
+++ b/themes/wezterm/base16-tube.toml
@@ -4,9 +4,9 @@
 background = "#231f20"
 foreground = "#d9d8d8"
 
-cursor_bg = "#1c3f95"
+cursor_bg = "#d9d8d8"
 cursor_border = "#d9d8d8"
-cursor_fg = "#e7e7e8"
+cursor_fg = "#231f20"
 
 selection_bg = "#d9d8d8"
 selection_fg = "#231f20"

--- a/themes/wezterm/base16-twilight.toml
+++ b/themes/wezterm/base16-twilight.toml
@@ -4,9 +4,9 @@
 background = "#1e1e1e"
 foreground = "#a7a7a7"
 
-cursor_bg = "#323537"
+cursor_bg = "#a7a7a7"
 cursor_border = "#a7a7a7"
-cursor_fg = "#c3c3c3"
+cursor_fg = "#1e1e1e"
 
 selection_bg = "#a7a7a7"
 selection_fg = "#1e1e1e"

--- a/themes/wezterm/base16-unikitty-dark.toml
+++ b/themes/wezterm/base16-unikitty-dark.toml
@@ -4,9 +4,9 @@
 background = "#2e2a31"
 foreground = "#bcbabe"
 
-cursor_bg = "#4a464d"
+cursor_bg = "#bcbabe"
 cursor_border = "#bcbabe"
-cursor_fg = "#d8d7da"
+cursor_fg = "#2e2a31"
 
 selection_bg = "#bcbabe"
 selection_fg = "#2e2a31"

--- a/themes/wezterm/base16-unikitty-light.toml
+++ b/themes/wezterm/base16-unikitty-light.toml
@@ -4,9 +4,9 @@
 background = "#ffffff"
 foreground = "#6c696e"
 
-cursor_bg = "#e1e1e2"
+cursor_bg = "#6c696e"
 cursor_border = "#6c696e"
-cursor_fg = "#4f4b51"
+cursor_fg = "#ffffff"
 
 selection_bg = "#6c696e"
 selection_fg = "#ffffff"

--- a/themes/wezterm/base16-unikitty-reversible.toml
+++ b/themes/wezterm/base16-unikitty-reversible.toml
@@ -4,9 +4,9 @@
 background = "#2e2a31"
 foreground = "#c3c2c4"
 
-cursor_bg = "#4b484e"
+cursor_bg = "#c3c2c4"
 cursor_border = "#c3c2c4"
-cursor_fg = "#e1e0e1"
+cursor_fg = "#2e2a31"
 
 selection_bg = "#c3c2c4"
 selection_fg = "#2e2a31"

--- a/themes/wezterm/base16-uwunicorn.toml
+++ b/themes/wezterm/base16-uwunicorn.toml
@@ -4,9 +4,9 @@
 background = "#241b26"
 foreground = "#eed5d9"
 
-cursor_bg = "#2f2a3f"
+cursor_bg = "#eed5d9"
 cursor_border = "#eed5d9"
-cursor_fg = "#d9c2c6"
+cursor_fg = "#241b26"
 
 selection_bg = "#eed5d9"
 selection_fg = "#241b26"

--- a/themes/wezterm/base16-valua.toml
+++ b/themes/wezterm/base16-valua.toml
@@ -4,9 +4,9 @@
 background = "#131f1f"
 foreground = "#98c1a3"
 
-cursor_bg = "#213132"
+cursor_bg = "#98c1a3"
 cursor_border = "#98c1a3"
-cursor_fg = "#a5cbb9"
+cursor_fg = "#131f1f"
 
 selection_bg = "#98c1a3"
 selection_fg = "#131f1f"

--- a/themes/wezterm/base16-vesper.toml
+++ b/themes/wezterm/base16-vesper.toml
@@ -4,9 +4,9 @@
 background = "#101010"
 foreground = "#b7b7b7"
 
-cursor_bg = "#232323"
+cursor_bg = "#b7b7b7"
 cursor_border = "#b7b7b7"
-cursor_fg = "#c1c1c1"
+cursor_fg = "#101010"
 
 selection_bg = "#b7b7b7"
 selection_fg = "#101010"

--- a/themes/wezterm/base16-vice.toml
+++ b/themes/wezterm/base16-vice.toml
@@ -4,9 +4,9 @@
 background = "#17191e"
 foreground = "#8b9cbe"
 
-cursor_bg = "#22262d"
+cursor_bg = "#8b9cbe"
 cursor_border = "#8b9cbe"
-cursor_fg = "#b2bfd9"
+cursor_fg = "#17191e"
 
 selection_bg = "#8b9cbe"
 selection_fg = "#17191e"

--- a/themes/wezterm/base16-vulcan.toml
+++ b/themes/wezterm/base16-vulcan.toml
@@ -4,9 +4,9 @@
 background = "#041523"
 foreground = "#5b778c"
 
-cursor_bg = "#122339"
+cursor_bg = "#5b778c"
 cursor_border = "#5b778c"
-cursor_fg = "#333238"
+cursor_fg = "#041523"
 
 selection_bg = "#5b778c"
 selection_fg = "#041523"

--- a/themes/wezterm/base16-windows-10-light.toml
+++ b/themes/wezterm/base16-windows-10-light.toml
@@ -4,9 +4,9 @@
 background = "#f2f2f2"
 foreground = "#767676"
 
-cursor_bg = "#e5e5e5"
+cursor_bg = "#767676"
 cursor_border = "#767676"
-cursor_fg = "#414141"
+cursor_fg = "#f2f2f2"
 
 selection_bg = "#767676"
 selection_fg = "#f2f2f2"

--- a/themes/wezterm/base16-windows-10.toml
+++ b/themes/wezterm/base16-windows-10.toml
@@ -4,9 +4,9 @@
 background = "#0c0c0c"
 foreground = "#cccccc"
 
-cursor_bg = "#2f2f2f"
+cursor_bg = "#cccccc"
 cursor_border = "#cccccc"
-cursor_fg = "#dfdfdf"
+cursor_fg = "#0c0c0c"
 
 selection_bg = "#cccccc"
 selection_fg = "#0c0c0c"

--- a/themes/wezterm/base16-windows-95-light.toml
+++ b/themes/wezterm/base16-windows-95-light.toml
@@ -4,9 +4,9 @@
 background = "#fcfcfc"
 foreground = "#545454"
 
-cursor_bg = "#e0e0e0"
+cursor_bg = "#545454"
 cursor_border = "#545454"
-cursor_fg = "#2a2a2a"
+cursor_fg = "#fcfcfc"
 
 selection_bg = "#545454"
 selection_fg = "#fcfcfc"

--- a/themes/wezterm/base16-windows-95.toml
+++ b/themes/wezterm/base16-windows-95.toml
@@ -4,9 +4,9 @@
 background = "#000000"
 foreground = "#a8a8a8"
 
-cursor_bg = "#1c1c1c"
+cursor_bg = "#a8a8a8"
 cursor_border = "#a8a8a8"
-cursor_fg = "#d2d2d2"
+cursor_fg = "#000000"
 
 selection_bg = "#a8a8a8"
 selection_fg = "#000000"

--- a/themes/wezterm/base16-windows-highcontrast-light.toml
+++ b/themes/wezterm/base16-windows-highcontrast-light.toml
@@ -4,9 +4,9 @@
 background = "#fcfcfc"
 foreground = "#545454"
 
-cursor_bg = "#e8e8e8"
+cursor_bg = "#545454"
 cursor_border = "#545454"
-cursor_fg = "#2a2a2a"
+cursor_fg = "#fcfcfc"
 
 selection_bg = "#545454"
 selection_fg = "#fcfcfc"

--- a/themes/wezterm/base16-windows-highcontrast.toml
+++ b/themes/wezterm/base16-windows-highcontrast.toml
@@ -4,9 +4,9 @@
 background = "#000000"
 foreground = "#c0c0c0"
 
-cursor_bg = "#1c1c1c"
+cursor_bg = "#c0c0c0"
 cursor_border = "#c0c0c0"
-cursor_fg = "#dedede"
+cursor_fg = "#000000"
 
 selection_bg = "#c0c0c0"
 selection_fg = "#000000"

--- a/themes/wezterm/base16-windows-nt-light.toml
+++ b/themes/wezterm/base16-windows-nt-light.toml
@@ -4,9 +4,9 @@
 background = "#ffffff"
 foreground = "#808080"
 
-cursor_bg = "#eaeaea"
+cursor_bg = "#808080"
 cursor_border = "#808080"
-cursor_fg = "#404040"
+cursor_fg = "#ffffff"
 
 selection_bg = "#808080"
 selection_fg = "#ffffff"

--- a/themes/wezterm/base16-windows-nt.toml
+++ b/themes/wezterm/base16-windows-nt.toml
@@ -4,9 +4,9 @@
 background = "#000000"
 foreground = "#c0c0c0"
 
-cursor_bg = "#2a2a2a"
+cursor_bg = "#c0c0c0"
 cursor_border = "#c0c0c0"
-cursor_fg = "#e0e0e0"
+cursor_fg = "#000000"
 
 selection_bg = "#c0c0c0"
 selection_fg = "#000000"

--- a/themes/wezterm/base16-woodland.toml
+++ b/themes/wezterm/base16-woodland.toml
@@ -4,9 +4,9 @@
 background = "#231e18"
 foreground = "#cabcb1"
 
-cursor_bg = "#302b25"
+cursor_bg = "#cabcb1"
 cursor_border = "#cabcb1"
-cursor_fg = "#d7c8bc"
+cursor_fg = "#231e18"
 
 selection_bg = "#cabcb1"
 selection_fg = "#231e18"

--- a/themes/wezterm/base16-xcode-dusk.toml
+++ b/themes/wezterm/base16-xcode-dusk.toml
@@ -4,9 +4,9 @@
 background = "#282b35"
 foreground = "#939599"
 
-cursor_bg = "#3d4048"
+cursor_bg = "#939599"
 cursor_border = "#939599"
-cursor_fg = "#a9aaae"
+cursor_fg = "#282b35"
 
 selection_bg = "#939599"
 selection_fg = "#282b35"

--- a/themes/wezterm/base16-zenbones.toml
+++ b/themes/wezterm/base16-zenbones.toml
@@ -4,9 +4,9 @@
 background = "#191919"
 foreground = "#b279a7"
 
-cursor_bg = "#de6e7c"
+cursor_bg = "#b279a7"
 cursor_border = "#b279a7"
-cursor_fg = "#66a5ad"
+cursor_fg = "#191919"
 
 selection_bg = "#b279a7"
 selection_fg = "#191919"

--- a/themes/wezterm/base16-zenburn.toml
+++ b/themes/wezterm/base16-zenburn.toml
@@ -4,9 +4,9 @@
 background = "#383838"
 foreground = "#dcdccc"
 
-cursor_bg = "#404040"
+cursor_bg = "#dcdccc"
 cursor_border = "#dcdccc"
-cursor_fg = "#c0c0c0"
+cursor_fg = "#383838"
 
 selection_bg = "#dcdccc"
 selection_fg = "#383838"


### PR DESCRIPTION
"Reverses" the colors of the cursor in the wezterm template, which can be quite hard to distinguish otherwise (depending on the chosen theme).

Uses background and foreground colors (instead of base01 and base06) since the base16-themes bundled with wezterm seem to do the same.