### PR TITLE
Add Konsole maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -39,6 +39,11 @@ README.md @tinted-theming/terminal
 /themes/kitty/* @tinted-theming/kitty-terminal
 /assets/kitty-icon.svg @tinted-theming/kitty-terminal
 
+# Konsole
+/templates/konsole-* @tinted-theming/konsole-terminal
+/themes/konsole/* @tinted-theming/konsole-terminal
+/assets/konsole-icon.svg @tinted-theming/konsole-terminal
+
 # PuTTY
 /templates/putty-* @tinted-theming/putty-terminal
 /themes/putty/* @tinted-theming/putty-terminal


### PR DESCRIPTION
@shanemcd this adds `tinted-theming/konsole-terminal` as the maintainer of the konsole files. It doesn't mean you can't touch anything else, it just auto notifies you when changes to those files are included in a PR. If you want to be included as a maintainer for the other templates, let me know and I can add you to them so you'll be notified in the case of those PRs. There aren't too many PRs in general though :)