### PR TITLE
fix: fixed alacritty template

### DIFF
--- a/templates/alacritty-base16.mustache
+++ b/templates/alacritty-base16.mustache
@@ -13,18 +13,18 @@ cursor = '0x{{base05-hex}}'
 
 # Normal colors
 [colors.normal]
-black = '0x{{base01-hex}}'
+black = '0x{{base00-hex}}'
 red = '0x{{base08-hex}}'
 green = '0x{{base0B-hex}}'
 yellow = '0x{{base0A-hex}}'
 blue = '0x{{base0D-hex}}'
 magenta = '0x{{base0E-hex}}'
 cyan = '0x{{base0C-hex}}'
-white = '0x{{base06-hex}}'
+white = '0x{{base05-hex}}'
 
 # Bright colors
 [colors.bright]
-black = '0x{{base02-hex}}'
+black = '0x{{base03-hex}}'
 red = '0x{{base08-hex}}'
 green = '0x{{base0B-hex}}'
 yellow = '0x{{base0A-hex}}'

--- a/templates/alacritty-base24.mustache
+++ b/templates/alacritty-base24.mustache
@@ -13,7 +13,7 @@ cursor = '0x{{base05-hex}}'
 
 # Normal colors
 [colors.normal]
-black = '0x{{base01-hex}}'
+black = '0x{{base00-hex}}'
 red = '0x{{base08-hex}}'
 green = '0x{{base0B-hex}}'
 yellow = '0x{{base0A-hex}}'
@@ -24,7 +24,7 @@ white = '0x{{base06-hex}}'
 
 # Bright colors
 [colors.bright]
-black = '0x{{base02-hex}}'
+black = '0x{{base03-hex}}'
 red = '0x{{base12-hex}}'
 green = '0x{{base14-hex}}'
 yellow = '0x{{base13-hex}}'
@@ -55,4 +55,4 @@ color = "0x{{base04-hex}}"
 
 [[colors.indexed_colors]]
 index = 21
-color = "0x{{base06-hex}}"
+color = "0x{{base05-hex}}"


### PR DESCRIPTION
Like in the previous PR where i addressed wezterm, i also found some false assginments in the alacritty template. 

```toml
[colors.normal]
black =      # Sets ANSI index 0
```

`base00` has ANSI index 0, not `base01`  and so on. please refer to

https://github.com/tinted-theming/home/blob/main/styling.md
https://github.com/tinted-theming/base24/blob/main/styling.md

Request for Review