### PR TITLE
ci: trigger update when patches committed to main

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,5 +1,8 @@
 name: Update with the latest tinted-theming colorschemes
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * 0" # https://crontab.guru/every-week


### PR DESCRIPTION
So new revisions, such as #44, can reach users more quickly. Close #45 

@JamyGolden 