### PR TITLE
Adjust tinted8 templates to use ui.cursor.* variables

### DIFF
--- a/templates/alacritty-tinted8.mustache
+++ b/templates/alacritty-tinted8.mustache
@@ -10,8 +10,8 @@ foreground = '0x{{ui.global.foreground.normal.hex}}'
 
 # Colors the cursor will use if `custom_cursor_colors` is true
 [colors.cursor]
-text = '0x{{ui.global.background.normal.hex}}'
-cursor = '0x{{ui.global.foreground.normal.hex}}'
+text = '0x{{ui.cursor.normal.foreground.hex}}'
+cursor = '0x{{ui.cursor.normal.background.hex}}'
 
 # Normal colors
 [colors.normal]

--- a/templates/ghostty-script-tinted8.mustache
+++ b/templates/ghostty-script-tinted8.mustache
@@ -38,9 +38,9 @@ ghostty_palette_color_15="#{{ palette.white.bright.hex }}"
 
 ghostty_ui_background_color="#{{ ui.global.background.normal.hex }}"
 ghostty_ui_foreground_color="#{{ ui.global.foreground.normal.hex }}"
-ghostty_ui_cursorcolor_color="#{{ palette.white.normal.hex }}"
+ghostty_ui_cursorcolor_color="#{{ ui.cursor.normal.foreground.hex }}"
 ghostty_ui_selectionbackground_color="#{{ ui.selection.background.hex }}"
-ghostty_ui_selectionforeground_color="#{{ ui.selection.global.foreground.hex }}"
+ghostty_ui_selectionforeground_color="#{{ ui.selection.foreground.hex }}"
 
 _theme_file() {
 cat <<EOF

--- a/templates/ghostty-tinted8.mustache
+++ b/templates/ghostty-tinted8.mustache
@@ -25,7 +25,7 @@ palette = 15=#{{ palette.white.bright.hex }}
 # Foreground & background colors
 background = #{{ ui.global.background.normal.hex }}
 foreground = #{{ ui.global.foreground.normal.hex }}
-cursor-color = #{{ palette.white.normal.hex }}
+cursor-color = #{{ ui.cursor.normal.foreground.hex }}
 selection-background = #{{ ui.selection.background.hex }}
 selection-foreground = #{{ ui.selection.foreground.hex }}
 

--- a/templates/iterm2-tinted8.mustache
+++ b/templates/iterm2-tinted8.mustache
@@ -211,22 +211,22 @@
         <key>Color Space</key>
         <string>sRGB</string>
         <key>Red Component</key>
-        <real>{{ui.global.foreground.normal.dec.r}}</real>
+        <real>{{ui.cursor.normal.background.dec.r}}</real>
         <key>Green Component</key>
-        <real>{{ui.global.foreground.normal.dec.g}}</real>
+        <real>{{ui.cursor.normal.background.dec.g}}</real>
         <key>Blue Component</key>
-        <real>{{ui.global.foreground.normal.dec.b}}</real>
+        <real>{{ui.cursor.normal.background.dec.b}}</real>
     </dict>
     <key>Cursor Text Color</key>
     <dict>
         <key>Color Space</key>
         <string>sRGB</string>
         <key>Red Component</key>
-        <real>{{ui.global.background.normal.dec.r}}</real>
+        <real>{{ui.cursor.normal.foreground.dec.r}}</real>
         <key>Green Component</key>
-        <real>{{ui.global.background.normal.dec.g}}</real>
+        <real>{{ui.cursor.normal.foreground.dec.g}}</real>
         <key>Blue Component</key>
-        <real>{{ui.global.background.normal.dec.b}}</real>
+        <real>{{ui.cursor.normal.foreground.dec.b}}</real>
     </dict>
     <key>Foreground Color</key>
     <dict>

--- a/templates/kermit-tinted8-16.mustache
+++ b/templates/kermit-tinted8-16.mustache
@@ -8,8 +8,8 @@ foreground         0x{{ui.global.foreground.normal.hex}}
 foreground_bold    0x{{ui.global.foreground.bright.hex}}
 
 # Cursor color
-cursor             0x{{ui.global.foreground.normal.hex}}
-cursor_foreground  0x{{ui.global.background.normal.hex}}
+cursor             0x{{ui.cursor.normal.background.hex}}
+cursor_foreground  0x{{ui.cursor.normal.foreground.hex}}
 
 # Background color
 background         0x{{ui.global.background.normal.hex}}

--- a/templates/kitty-tinted8.mustache
+++ b/templates/kitty-tinted8.mustache
@@ -12,8 +12,8 @@ selection_background #{{ui.selection.foreground.hex}}
 selection_foreground #{{ui.selection.foreground.hex}}
 
 # Cursor colors
-cursor #{{ui.global.foreground.normal.hex}}
-cursor_text_color #{{ui.global.background.normal.hex}}
+cursor #{{ui.cursor.normal.background.hex}}
+cursor_text_color #{{ui.cursor.normal.foreground.hex}}
 
 # URL underline color when hovering with mouse
 url_color #{{palette.gray.normal.hex}}

--- a/templates/mintty-tinted8.mustache
+++ b/templates/mintty-tinted8.mustache
@@ -24,4 +24,4 @@ BoldWhite   = #{{ palette.white.bright.hex }}
 # Background & foreground colors
 BackgroundColour = #{{ ui.global.background.normal.hex }}
 ForegroundColour = #{{ ui.global.foreground.normal.hex }}
-CursorColour     = #{{ ui.global.foreground.normal.hex }}
+CursorColour     = #{{ ui.cursor.normal.background.hex }}

--- a/templates/putty-tinted8.mustache
+++ b/templates/putty-tinted8.mustache
@@ -24,12 +24,12 @@ Windows Registry Editor Version 5.00
 "Colour3"="{{ui.global.background.bright.rgb.r}},{{ui.global.background.bright.rgb.g}},{{ui.global.background.bright.rgb.b}}"
 
 ; Cursor Text
-; #{{ui.global.background.normal.hex}}
-"Colour4"="{{ui.global.background.normal.rgb.r}},{{ui.global.background.normal.rgb.g}},{{ui.global.background.normal.rgb.b}}"
+; #{{ui.cursor.normal.foreground.hex}}
+"Colour4"="{{ui.cursor.normal.foreground.rgb.r}},{{ui.cursor.normal.foreground.rgb.b}},{{ui.cursor.normal.foreground.rgb.b}}"
 
 ; Cursor Colour
-; #{{ui.global.foreground.normal.hex}}
-"Colour5"="{{ui.global.foreground.normal.rgb.r}},{{ui.global.foreground.normal.rgb.g}},{{ui.global.foreground.normal.rgb.b}}"
+; #{ui.cursor.normal.background.hex}
+"Colour5"="{{ui.cursor.normal.background.rgb.r}},{{ui.cursor.normal.background.rgb.g}},{{ui.cursor.normal.background.rgb.b}}"
 
 ; ANSI Black
 ; 30m

--- a/templates/rio-tinted8-16.mustache
+++ b/templates/rio-tinted8-16.mustache
@@ -5,7 +5,7 @@
 selection-background = '#{{ui.selection.background.hex}}'
 selection-foreground = '#{{ui.selection.foreground.hex}}'
 
-cursor         = '#{{ui.selection.foreground.hex}}'
+cursor         = '#{{ui.cursor.normal.background.hex}}'
 tabs           = '#{{palette.black.bright.hex}}'
 tabs-active    = '#{{palette.gray.dim.hex}}'
 

--- a/templates/termite-tinted8.mustache
+++ b/templates/termite-tinted8.mustache
@@ -4,9 +4,9 @@
 # Template author: Tinted Theming (https://github.com/tinted-theming/tinted-termite)
 
 foreground          = #{{ui.global.foreground.normal.hex}}
-foreground_bold     = #{{ui.global.foreground.normal.hex}}
-cursor              = #{{ui.global.foreground.normal.hex}}
-cursor_foreground   = #{{ui.global.background.normal.hex}}
+foreground_bold     = #{{ui.global.foreground.bright.hex}}
+cursor              = #{{ui.cursor.normal.background.hex}}
+cursor_foreground   = #{{ui.cursor.normal.foreground.hex}}
 background          = #{{ui.global.background.normal.hex}}
 
 color0  = #{{palette.black.normal.hex}}   # Black
@@ -25,4 +25,3 @@ color12 = #{{palette.blue.bright.hex}}    # Bright Blue
 color13 = #{{palette.magenta.bright.hex}} # Bright Magenta
 color14 = #{{palette.cyan.bright.hex}}    # Bright Cyan
 color15 = #{{palette.white.bright.hex}}   # Bright White
-

--- a/templates/wezterm-tinted8.mustache
+++ b/templates/wezterm-tinted8.mustache
@@ -6,9 +6,9 @@
 background = "#{{ui.global.background.normal.hex}}"
 foreground = "#{{ui.global.foreground.normal.hex}}"
 
-cursor_bg = "#{{ui.global.foreground.normal.hex}}"
-cursor_border = "#{{ui.global.foreground.normal.hex}}"
-cursor_fg = "#{{ui.global.background.normal.hex}}"
+cursor_bg = "#{{ui.cursor.normal.background.hex}}"
+cursor_border = "#{{ui.cursor.normal.background.hex}}"
+cursor_fg = "#{{ui.cursor.normal.foreground.hex}}"
 
 selection_bg = "#{{ui.selection.background.hex}}"
 selection_fg = "#{{ui.selection.foreground.hex}}"

--- a/templates/xfce4-tinted8.mustache
+++ b/templates/xfce4-tinted8.mustache
@@ -5,7 +5,7 @@
 Name={{scheme.system}}-{{scheme.slug}}
 ColorForeground=#{{ui.global.foreground.normal.hex}}
 ColorBackground=#{{ui.global.background.normal.hex}}
-ColorCursor=#{{ui.global.foreground.normal.hex}}
+ColorCursor=#{{ui.cursor.normal.background.hex}}
 ColorBoldIsBright=FALSE
 ColorPalette=#{{palette.black.normal.hex}};#{{palette.red.normal.hex}};#{{palette.green.normal.hex}};#{{palette.yellow.normal.hex}};#{{palette.blue.normal.hex}};#{{palette.magenta.normal.hex}};#{{palette.cyan.normal.hex}};#{{palette.white.normal.hex}};#{{palette.black.bright.hex}};#{{palette.red.bright.hex}};#{{palette.green.bright.hex}};#{{palette.yellow.bright.hex}};#{{palette.blue.bright.hex}};#{{palette.magenta.bright.hex}};#{{palette.cyan.bright.hex}};#{{palette.white.bright.hex}}
 


### PR DESCRIPTION
Use `ui.cursor.<foreground|background>` in place of global foreground and background color for cursors in [tinted8](https://github.com/tinted-theming/home/blob/main/specs/tinted8/styling.md) templates.