### PR TITLE
Fix Konsole theme switching inside tmux

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ Tinted Theming template for [Konsole terminal emulator].
    path = "https://github.com/tinted-theming/tinted-terminal"
    name = "tinted-terminal"
    themes-dir = "themes/konsole"
-   hook = "cp -f %f ~/.local/share/konsole/%n.colorscheme && konsoleprofile ColorScheme=%n"
+   hook = "cp -f \"$TINTY_THEME_FILE_PATH\" ~/.local/share/konsole/$TINTY_SCHEME_ID.colorscheme && \"$TINTY_REPO_PATH/scripts/konsoleprofile.sh\" ColorScheme=$TINTY_SCHEME_ID"
    supported-systems = ["base16", "base24"]
    ```
 

--- a/scripts/konsoleprofile.sh
+++ b/scripts/konsoleprofile.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Wrapper around konsoleprofile that supports tmux passthrough.
+#
+# konsoleprofile works by sending an OSC 50 escape sequence to the
+# terminal. When running inside tmux, these sequences are intercepted
+# and discarded unless explicitly wrapped in a DCS passthrough.
+#
+# When inside tmux, this script temporarily enables allow-passthrough,
+# sends the escape sequence, then restores the previous setting.
+#
+# Usage: konsoleprofile.sh <profile-options>
+# Example: konsoleprofile.sh "ColorScheme=base16-ayu-dark"
+
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 \"option=value[;option=value;...]\"" >&2
+    exit 1
+fi
+
+if [ -n "$TMUX" ]; then
+    prev="$(tmux show -gv allow-passthrough 2>/dev/null)"
+    tmux set -g allow-passthrough on >/dev/null 2>&1
+    printf '\033Ptmux;\033\033]50;%s\a\033\\' "$1"
+    tmux set -g allow-passthrough "$prev" >/dev/null 2>&1
+else
+    printf '\033]50;%s\a' "$1"
+fi


### PR DESCRIPTION
Fixes #37

Adds `scripts/konsoleprofile.sh` to wrap `konsoleprofile` escape sequences (`OSC 50`) inside a tmux DCS passthrough when running within tmux. Also updates the Konsole hook in `README.md` to use `$TINTY_REPO_PATH/scripts/konsoleprofile.sh`.

This complements [tinted-theming/tinty#188](https://github.com/tinted-theming/tinty/pull/188) which exposes `TINTY_REPO_PATH` to hooks. Even though we haven't heard back from the issue author on #37 yet, this fix ensures Konsole profile switching works seamlessly inside tmux.